### PR TITLE
Add `deserializeAny` method to `getty.Deserializer`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: ci
 on:
   push:
-    branches: [ main ]
+    branches: [main, develop]
   pull_request:
-    branches: [ main ]
+    branches: [main, develop]
 
 jobs:
   lint:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,7 @@
 name: docs
 on:
   push:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   docs:

--- a/src/de.zig
+++ b/src/de.zig
@@ -52,7 +52,10 @@ pub const traits = struct {
 
 /// Namespace for deserialization-specific types and functions.
 pub const de = struct {
-    /// A generic error set for `getty.de.Visitor` implementations.
+    /// A generic error set for `getty.Deserializer` implementations.
+    ///
+    /// This error set must always be included in a `getty.Deserializer`
+    /// implementation's error set.
     pub const Error = std.mem.Allocator.Error || error{
         DuplicateField,
         InvalidLength,

--- a/src/de.zig
+++ b/src/de.zig
@@ -472,148 +472,87 @@ const TestDeserializer = struct {
         default_dt,
         default_dt,
         .{
-            .deserializeBool = deserializeBool,
-            .deserializeEnum = deserializeEnum,
-            .deserializeFloat = deserializeFloat,
-            .deserializeInt = deserializeInt,
-            .deserializeMap = deserializeMap,
-            .deserializeOptional = deserializeOptional,
-            .deserializeSeq = deserializeSeq,
-            .deserializeString = deserializeString,
-            .deserializeStruct = deserializeStruct,
-            .deserializeUnion = deserializeUnion,
-            .deserializeVoid = deserializeVoid,
+            .deserializeAny = deserializeAny,
+            .deserializeBool = deserializeAny,
+            .deserializeEnum = deserializeAny,
+            .deserializeFloat = deserializeAny,
+            .deserializeInt = deserializeAny,
+            .deserializeMap = deserializeAny,
+            .deserializeOptional = deserializeAny,
+            .deserializeSeq = deserializeAny,
+            .deserializeString = deserializeAny,
+            .deserializeStruct = deserializeAny,
+            .deserializeUnion = deserializeAny,
+            .deserializeVoid = deserializeAny,
         },
     );
 
     const Error = de.Error || error{TestExpectedEqual};
 
-    fn deserializeBool(self: *Self, allocator: ?std.mem.Allocator, visitor: anytype) Error!@TypeOf(visitor).Value {
-        switch (self.nextToken()) {
-            .Bool => |v| return try visitor.visitBool(allocator, Self.@"getty.Deserializer", v),
-            else => |v| std.debug.panic("deserialization did not expect this token: {s}", .{@tagName(v)}),
-        }
-    }
+    const De = Self.@"getty.Deserializer";
 
-    fn deserializeEnum(self: *Self, allocator: ?std.mem.Allocator, visitor: anytype) Error!@TypeOf(visitor).Value {
-        switch (self.nextToken()) {
+    fn deserializeAny(self: *Self, allocator: ?std.mem.Allocator, visitor: anytype) Error!@TypeOf(visitor).Value {
+        return switch (self.nextToken()) {
+            .Bool => |v| try visitor.visitBool(allocator, De, v),
+            .I8 => |v| try visitor.visitInt(allocator, De, v),
+            .I16 => |v| try visitor.visitInt(allocator, De, v),
+            .I32 => |v| try visitor.visitInt(allocator, De, v),
+            .I64 => |v| try visitor.visitInt(allocator, De, v),
+            .I128 => |v| try visitor.visitInt(allocator, De, v),
+            .U8 => |v| try visitor.visitInt(allocator, De, v),
+            .U16 => |v| try visitor.visitInt(allocator, De, v),
+            .U32 => |v| try visitor.visitInt(allocator, De, v),
+            .U64 => |v| try visitor.visitInt(allocator, De, v),
+            .U128 => |v| try visitor.visitInt(allocator, De, v),
+            .F16 => |v| try visitor.visitFloat(allocator, De, v),
+            .F32 => |v| try visitor.visitFloat(allocator, De, v),
+            .F64 => |v| try visitor.visitFloat(allocator, De, v),
+            .F128 => |v| try visitor.visitFloat(allocator, De, v),
             .Enum => switch (self.nextToken()) {
-                .U8 => |v| return try visitor.visitInt(allocator, Self.@"getty.Deserializer", v),
-                .U16 => |v| return try visitor.visitInt(allocator, Self.@"getty.Deserializer", v),
-                .U32 => |v| return try visitor.visitInt(allocator, Self.@"getty.Deserializer", v),
-                .U64 => |v| return try visitor.visitInt(allocator, Self.@"getty.Deserializer", v),
-                .U128 => |v| return try visitor.visitInt(allocator, Self.@"getty.Deserializer", v),
-                .String => |v| return try visitor.visitString(allocator, Self.@"getty.Deserializer", v),
+                .U8 => |v| try visitor.visitInt(allocator, De, v),
+                .U16 => |v| try visitor.visitInt(allocator, De, v),
+                .U32 => |v| try visitor.visitInt(allocator, De, v),
+                .U64 => |v| try visitor.visitInt(allocator, De, v),
+                .U128 => |v| try visitor.visitInt(allocator, De, v),
+                .String => |v| try visitor.visitString(allocator, De, v),
                 else => |v| std.debug.panic("deserialization did not expect this token: {s}", .{@tagName(v)}),
             },
-            else => |v| std.debug.panic("deserialization did not expect this token: {s}", .{@tagName(v)}),
-        }
-    }
-
-    fn deserializeFloat(self: *Self, allocator: ?std.mem.Allocator, visitor: anytype) Error!@TypeOf(visitor).Value {
-        return switch (self.nextToken()) {
-            .F16 => |v| try visitor.visitFloat(allocator, Self.@"getty.Deserializer", v),
-            .F32 => |v| try visitor.visitFloat(allocator, Self.@"getty.Deserializer", v),
-            .F64 => |v| try visitor.visitFloat(allocator, Self.@"getty.Deserializer", v),
-            .F128 => |v| try visitor.visitFloat(allocator, Self.@"getty.Deserializer", v),
-            else => |v| std.debug.panic("deserialization did not expect this token: {s}", .{@tagName(v)}),
-        };
-    }
-
-    fn deserializeInt(self: *Self, allocator: ?std.mem.Allocator, visitor: anytype) Error!@TypeOf(visitor).Value {
-        return switch (self.nextToken()) {
-            .I8 => |v| try visitor.visitInt(allocator, Self.@"getty.Deserializer", v),
-            .I16 => |v| try visitor.visitInt(allocator, Self.@"getty.Deserializer", v),
-            .I32 => |v| try visitor.visitInt(allocator, Self.@"getty.Deserializer", v),
-            .I64 => |v| try visitor.visitInt(allocator, Self.@"getty.Deserializer", v),
-            .I128 => |v| try visitor.visitInt(allocator, Self.@"getty.Deserializer", v),
-            .U8 => |v| try visitor.visitInt(allocator, Self.@"getty.Deserializer", v),
-            .U16 => |v| try visitor.visitInt(allocator, Self.@"getty.Deserializer", v),
-            .U32 => |v| try visitor.visitInt(allocator, Self.@"getty.Deserializer", v),
-            .U64 => |v| try visitor.visitInt(allocator, Self.@"getty.Deserializer", v),
-            .U128 => |v| try visitor.visitInt(allocator, Self.@"getty.Deserializer", v),
-            else => |v| std.debug.panic("deserialization did not expect this token: {s}", .{@tagName(v)}),
-        };
-    }
-
-    fn deserializeMap(self: *Self, allocator: ?std.mem.Allocator, visitor: anytype) Error!@TypeOf(visitor).Value {
-        switch (self.nextToken()) {
-            .Map => |v| {
+            .Null => try visitor.visitNull(allocator, De),
+            .Some => try visitor.visitSome(allocator, self.deserializer()),
+            .String => |v| try visitor.visitString(allocator, De, v),
+            .Void => try visitor.visitVoid(allocator, De),
+            .Map => |v| blk: {
                 var m = Map{ .de = self, .len = v.len, .end = .MapEnd };
-                var value = visitor.visitMap(allocator, Self.@"getty.Deserializer", m.mapAccess());
+                var value = try visitor.visitMap(allocator, De, m.mapAccess());
 
                 try self.assertNextToken(.MapEnd);
 
-                return value;
+                break :blk value;
             },
-            else => |v| std.debug.panic("deserialization did not expect this token: {s}", .{@tagName(v)}),
-        }
-    }
-
-    fn deserializeOptional(self: *Self, allocator: ?std.mem.Allocator, visitor: anytype) Error!@TypeOf(visitor).Value {
-        switch (self.peekToken()) {
-            .Null => {
-                _ = self.nextToken();
-                return try visitor.visitNull(allocator, Self.@"getty.Deserializer");
-            },
-            .Some => {
-                _ = self.nextToken();
-                return try visitor.visitSome(allocator, self.deserializer());
-            },
-            else => |v| std.debug.panic("deserialization did not expect this token: {s}", .{@tagName(v)}),
-        }
-    }
-
-    fn deserializeSeq(self: *Self, allocator: ?std.mem.Allocator, visitor: anytype) Error!@TypeOf(visitor).Value {
-        switch (self.nextToken()) {
-            .Seq => |v| {
+            .Seq => |v| blk: {
                 var s = Seq{ .de = self, .len = v.len, .end = .SeqEnd };
-                var value = visitor.visitSeq(allocator, Self.@"getty.Deserializer", s.seqAccess());
+                var value = try visitor.visitSeq(allocator, De, s.seqAccess());
 
                 try self.assertNextToken(.SeqEnd);
 
-                return value;
+                break :blk value;
             },
-            else => |v| std.debug.panic("deserialization did not expect this token: {s}", .{@tagName(v)}),
-        }
-    }
-
-    fn deserializeString(self: *Self, allocator: ?std.mem.Allocator, visitor: anytype) Error!@TypeOf(visitor).Value {
-        switch (self.nextToken()) {
-            .String => |v| return try visitor.visitString(allocator, Self.@"getty.Deserializer", v),
-            else => |v| std.debug.panic("deserialization did not expect this token: {s}", .{@tagName(v)}),
-        }
-    }
-
-    fn deserializeStruct(self: *Self, allocator: ?std.mem.Allocator, visitor: anytype) Error!@TypeOf(visitor).Value {
-        switch (self.nextToken()) {
-            .Struct => |v| {
+            .Struct => |v| blk: {
                 var s = Struct{ .de = self, .len = v.len, .end = .StructEnd };
-                var value = visitor.visitMap(allocator, Self.@"getty.Deserializer", s.mapAccess());
+                var value = try visitor.visitMap(allocator, De, s.mapAccess());
 
                 try self.assertNextToken(.StructEnd);
 
-                return value;
+                break :blk value;
             },
-            else => |v| std.debug.panic("deserialization did not expect this token: {s}", .{@tagName(v)}),
-        }
-    }
-
-    fn deserializeUnion(self: *Self, allocator: ?std.mem.Allocator, visitor: anytype) Error!@TypeOf(visitor).Value {
-        switch (self.nextToken()) {
-            .Union => {
+            .Union => blk: {
                 var u = Union{ .de = self };
-                return visitor.visitUnion(allocator, Self.@"getty.Deserializer", u.unionAccess(), u.variantAccess());
+                break :blk try visitor.visitUnion(allocator, De, u.unionAccess(), u.variantAccess());
             },
-            else => |v| std.debug.panic("deserialization did not expect this token: {s}", .{@tagName(v)}),
-        }
-    }
 
-    fn deserializeVoid(self: *Self, allocator: ?std.mem.Allocator, visitor: anytype) Error!@TypeOf(visitor).Value {
-        switch (self.nextToken()) {
-            .Void => return try visitor.visitVoid(allocator, Self.@"getty.Deserializer"),
+            // Panic! At The Disco
             else => |v| std.debug.panic("deserialization did not expect this token: {s}", .{@tagName(v)}),
-        }
+        };
     }
 
     fn assertNextToken(self: *Self, expected: Token) !void {
@@ -1061,6 +1000,7 @@ test "deserialize - string" {
 
     {
         var arr = [_:0]u8{ 'a', 'b', 'c' };
+
         // Sentinel
         try t("abc", &[_]Token{
             .{ .Seq = .{ .len = 3 } },

--- a/src/de/concepts/deserializer.zig
+++ b/src/de/concepts/deserializer.zig
@@ -17,6 +17,7 @@ pub fn @"getty.Deserializer"(
             "dt",
             "user_dt",
             "deserializer_dt",
+            "deserializeAny",
             "deserializeBool",
             "deserializeEnum",
             "deserializeFloat",

--- a/src/de/error.zig
+++ b/src/de/error.zig
@@ -1,0 +1,14 @@
+const std = @import("std");
+
+/// A generic error set for `getty.de.Visitor` implementations.
+pub const Error = std.mem.Allocator.Error || error{
+    DuplicateField,
+    InvalidLength,
+    InvalidType,
+    InvalidValue,
+    MissingField,
+    MissingVariant,
+    UnknownField,
+    UnknownVariant,
+    Unsupported,
+};

--- a/src/de/impls/visitor/buf_map.zig
+++ b/src/de/impls/visitor/buf_map.zig
@@ -18,13 +18,13 @@ pub fn Visitor(comptime BufMap: type) type {
             var m = BufMap.init(allocator.?);
             errdefer de.free(allocator.?, m);
 
-            while (try map.nextKey(allocator, []u8)) |k| {
-                errdefer de.free(allocator.?, k);
+            while (try map.nextKey(allocator, []const u8)) |k| {
+                defer de.free(allocator.?, k);
 
-                const v = try map.nextValue(allocator, []u8);
-                errdefer de.free(allocator.?, v);
+                const v = try map.nextValue(allocator, []const u8);
+                defer de.free(allocator.?, v);
 
-                try m.putMove(k, v);
+                try m.put(k, v);
             }
 
             return m;

--- a/src/de/impls/visitor/slice.zig
+++ b/src/de/impls/visitor/slice.zig
@@ -25,7 +25,12 @@ pub fn Visitor(comptime Slice: type) type {
                 try list.append(elem);
             }
 
-            return list.toOwnedSlice();
+            if (@typeInfo(Value).Pointer.sentinel) |s| {
+                const sentinel_char = @ptrCast(*const Child, s).*;
+                return try list.toOwnedSliceSentinel(sentinel_char);
+            }
+
+            return try list.toOwnedSlice();
         }
 
         fn visitString(_: Self, allocator: ?std.mem.Allocator, comptime Deserializer: type, input: anytype) Deserializer.Error!Value {

--- a/src/de/interfaces/deserializer.zig
+++ b/src/de/interfaces/deserializer.zig
@@ -20,6 +20,7 @@ pub fn Deserializer(
             }
         }.f);
 
+        deserializeAny: T = null,
         deserializeBool: T = null,
         deserializeEnum: T = null,
         deserializeFloat: T = null,
@@ -142,6 +143,15 @@ pub fn Deserializer(
                     break :blk user_dt ++ deserializer_dt ++ de.default_dt;
                 }
             };
+
+            /// Deserializes a deserializer's input data into some Getty value.
+            pub fn deserializeAny(self: Self, allocator: ?std.mem.Allocator, visitor: anytype) Return(@TypeOf(visitor)) {
+                if (methods.deserializeAny) |f| {
+                    return try f(self.context, allocator, visitor);
+                }
+
+                @compileError("deserializeAny is not implemented by type: " ++ @typeName(Context));
+            }
 
             /// Deserializes a deserializer's input data into a Getty Boolean.
             pub fn deserializeBool(self: Self, allocator: ?std.mem.Allocator, visitor: anytype) Return(@TypeOf(visitor)) {

--- a/src/de/interfaces/deserializer.zig
+++ b/src/de/interfaces/deserializer.zig
@@ -49,7 +49,13 @@ pub fn Deserializer(
             const Self = @This();
 
             /// Error set used upon failure.
-            pub const Error = E;
+            pub const Error = blk: {
+                if (E != E || de.de.Error) {
+                    @compileError("error set must include `getty.de.Error`");
+                }
+
+                break :blk E;
+            };
 
             /// User-defined Deserialization Tuple.
             pub const user_dt = blk: {
@@ -246,17 +252,17 @@ pub fn Deserializer(
 
                 @compileError("deserializeVoid is not implemented by type: " ++ @typeName(Context));
             }
+
+            fn Return(comptime Visitor: type) type {
+                comptime de.concepts.@"getty.de.Visitor"(Visitor);
+
+                return Error!Visitor.Value;
+            }
         };
 
         /// Returns an interface value.
         pub fn deserializer(self: Context) @"getty.Deserializer" {
             return .{ .context = self };
-        }
-
-        fn Return(comptime Visitor: type) type {
-            comptime de.concepts.@"getty.de.Visitor"(Visitor);
-
-            return E!Visitor.Value;
         }
     };
 }

--- a/src/de/interfaces/visitor.zig
+++ b/src/de/interfaces/visitor.zig
@@ -83,7 +83,7 @@ pub fn Visitor(
                     return try f(self.context, allocator, Deserializer, input);
                 }
 
-                @compileError("visitBool is not implemented by type: " ++ @typeName(Context));
+                return error.Unsupported;
             }
 
             pub fn visitEnum(self: Self, allocator: ?std.mem.Allocator, comptime Deserializer: type, input: anytype) Deserializer.Error!Value {
@@ -98,7 +98,7 @@ pub fn Visitor(
                     return try f(self.context, allocator, Deserializer, input);
                 }
 
-                @compileError("visitEnum is not implemented by type: " ++ @typeName(Context));
+                return error.Unsupported;
             }
 
             pub fn visitFloat(self: Self, allocator: ?std.mem.Allocator, comptime Deserializer: type, input: anytype) Deserializer.Error!Value {
@@ -113,7 +113,7 @@ pub fn Visitor(
                     return try f(self.context, allocator, Deserializer, input);
                 }
 
-                @compileError("visitFloat is not implemented by type: " ++ @typeName(Context));
+                return error.Unsupported;
             }
 
             pub fn visitInt(self: Self, allocator: ?std.mem.Allocator, comptime Deserializer: type, input: anytype) Deserializer.Error!Value {
@@ -128,7 +128,7 @@ pub fn Visitor(
                     return try f(self.context, allocator, Deserializer, input);
                 }
 
-                @compileError("visitInt is not implemented by type: " ++ @typeName(Context));
+                return error.Unsupported;
             }
 
             pub fn visitMap(self: Self, allocator: ?std.mem.Allocator, comptime Deserializer: type, map: anytype) blk: {
@@ -140,7 +140,7 @@ pub fn Visitor(
                     return try f(self.context, allocator, Deserializer, map);
                 }
 
-                @compileError("visitMap is not implemented by type: " ++ @typeName(Context));
+                return error.Unsupported;
             }
 
             pub fn visitNull(self: Self, allocator: ?std.mem.Allocator, comptime Deserializer: type) Deserializer.Error!Value {
@@ -148,7 +148,7 @@ pub fn Visitor(
                     return try f(self.context, allocator, Deserializer);
                 }
 
-                @compileError("visitNull is not implemented by type: " ++ @typeName(Context));
+                return error.Unsupported;
             }
 
             ///
@@ -165,7 +165,7 @@ pub fn Visitor(
                     return try f(self.context, allocator, Deserializer, seq);
                 }
 
-                @compileError("visitSeq is not implemented by type: " ++ @typeName(Context));
+                return error.Unsupported;
             }
 
             pub fn visitSome(self: Self, allocator: ?std.mem.Allocator, deserializer: anytype) blk: {
@@ -177,7 +177,7 @@ pub fn Visitor(
                     return try f(self.context, allocator, deserializer);
                 }
 
-                @compileError("visitSome is not implemented by type: " ++ @typeName(Context));
+                return error.Unsupported;
             }
 
             ///
@@ -194,7 +194,7 @@ pub fn Visitor(
                     return try f(self.context, allocator, Deserializer, input);
                 }
 
-                @compileError("visitString is not implemented by type: " ++ @typeName(Context));
+                return error.Unsupported;
             }
 
             pub fn visitUnion(self: Self, allocator: ?std.mem.Allocator, comptime Deserializer: type, ua: anytype, va: anytype) blk: {
@@ -207,7 +207,7 @@ pub fn Visitor(
                     return try f(self.context, allocator, Deserializer, ua, va);
                 }
 
-                @compileError("visitUnion is not implemented by type: " ++ @typeName(Context));
+                return error.Unsupported;
             }
 
             pub fn visitVoid(self: Self, allocator: ?std.mem.Allocator, comptime Deserializer: type) Deserializer.Error!Value {
@@ -215,7 +215,7 @@ pub fn Visitor(
                     return try f(self.context, allocator, Deserializer);
                 }
 
-                @compileError("visitVoid is not implemented by type: " ++ @typeName(Context));
+                return error.Unsupported;
             }
         };
 


### PR DESCRIPTION
Three main changes in this PR:

1. `getty.Deserializer` implementations must now always include `getty.de.Error` in their error set.
1. Visitors now return `error.Unsupported` instead of raising a compile error.
1. `getty.Deserializer` now has a `deserializeAny` method, enabling deserializers of self-describing formats to deserialize solely based off of their input.

Closes #21.