### PR TITLE
ser, de: Check SBTs and DBTs for attributes

### DIFF
--- a/src/de/traits/attributes.zig
+++ b/src/de/traits/attributes.zig
@@ -8,11 +8,11 @@ const Attributes = @import("../../attributes.zig").Attributes;
 pub fn has_attributes(
     /// A type with attributes.
     comptime T: type,
-    /// A type-defined deserialization block.
-    comptime TDB: type,
+    /// A deserialization block.
+    comptime DB: type,
 ) bool {
     comptime {
-        return is_tdb(TDB) and @hasDecl(TDB, "attributes") and is_attributes(T, TDB.attributes);
+        return (is_dbt(DB) or is_tdb(DB)) and @hasDecl(DB, "attributes") and is_attributes(T, DB.attributes);
     }
 }
 

--- a/src/ser/traits/attributes.zig
+++ b/src/ser/traits/attributes.zig
@@ -8,11 +8,11 @@ const Attributes = @import("../../attributes.zig").Attributes;
 pub fn has_attributes(
     /// A type with attributes.
     comptime T: type,
-    /// A type-defined serialization block.
-    comptime TSB: type,
+    /// A serialization block.
+    comptime SB: type,
 ) bool {
     comptime {
-        return is_tsb(TSB) and @hasDecl(TSB, "attributes") and is_attributes(T, TSB.attributes);
+        return (is_sbt(SB) or is_tsb(SB)) and @hasDecl(SB, "attributes") and is_attributes(T, SB.attributes);
     }
 }
 


### PR DESCRIPTION
has_attributes was incorrectly checking only TSBs and TDBs.