### PR TITLE
ser, de: Replace field_type with type

### DIFF
--- a/src/attributes.zig
+++ b/src/attributes.zig
@@ -263,7 +263,7 @@ pub fn Attributes(comptime T: type, comptime attributes: anytype) type {
                 // passed-in value, add the inner attribute to the fields array.
                 fields[i] = .{
                     .name = field.name,
-                    .field_type = InnerAttributes,
+                    .type = InnerAttributes,
                     .default_value = inner,
                     .is_comptime = false,
                     .alignment = 4,
@@ -273,7 +273,7 @@ pub fn Attributes(comptime T: type, comptime attributes: anytype) type {
                 // "Container", add the container attribute to the fields array.
                 fields[i] = .{
                     .name = "Container",
-                    .field_type = ContainerAttributes,
+                    .type = ContainerAttributes,
                     .default_value = container,
                     .is_comptime = false,
                     .alignment = 4,

--- a/src/de/impls/visitor/hash_map.zig
+++ b/src/de/impls/visitor/hash_map.zig
@@ -15,8 +15,8 @@ pub fn Visitor(comptime HashMap: type) type {
         const Value = HashMap;
 
         fn visitMap(_: Self, allocator: ?std.mem.Allocator, comptime Deserializer: type, map: anytype) Deserializer.Error!Value {
-            const K = std.meta.fieldInfo(Value.KV, .key).field_type;
-            const V = std.meta.fieldInfo(Value.KV, .value).field_type;
+            const K = std.meta.fieldInfo(Value.KV, .key).type;
+            const V = std.meta.fieldInfo(Value.KV, .value).type;
             const unmanaged = comptime std.mem.startsWith(
                 u8,
                 @typeName(Value),

--- a/src/de/impls/visitor/struct.zig
+++ b/src/de/impls/visitor/struct.zig
@@ -85,7 +85,7 @@ pub fn Visitor(comptime Struct: type) type {
 
                                 if (@hasField(@TypeOf(attr), "skip") and attr.skip) {
                                     // Skip value, but check its validity.
-                                    _ = try map.nextValue(allocator, field.field_type);
+                                    _ = try map.nextValue(allocator, field.type);
 
                                     // Move on to next key.
                                     continue :key_loop;
@@ -95,7 +95,7 @@ pub fn Visitor(comptime Struct: type) type {
 
                         // Deserialize and assign value to field.
                         switch (field.is_comptime) {
-                            false => @field(structure, field.name) = try map.nextValue(allocator, field.field_type),
+                            false => @field(structure, field.name) = try map.nextValue(allocator, field.type),
                             true => @compileError("TODO"),
                         }
 
@@ -120,8 +120,8 @@ pub fn Visitor(comptime Struct: type) type {
                 if (!seen[i]) {
                     if (field.default_value) |default_ptr| {
                         if (!field.is_comptime) {
-                            const aligned_default_ptr = @alignCast(@alignOf(field.field_type), default_ptr);
-                            const default_value = @ptrCast(*const field.field_type, aligned_default_ptr).*;
+                            const aligned_default_ptr = @alignCast(@alignOf(field.type), default_ptr);
+                            const default_value = @ptrCast(*const field.type, aligned_default_ptr).*;
                             @field(structure, field.name) = default_value;
                         }
                     } else {

--- a/src/de/impls/visitor/tail_queue.zig
+++ b/src/de/impls/visitor/tail_queue.zig
@@ -18,7 +18,7 @@ pub fn Visitor(comptime TailQueue: type) type {
             var list = Value{};
             errdefer de.free(allocator.?, list);
 
-            const Child = std.meta.fieldInfo(Value.Node, .data).field_type;
+            const Child = std.meta.fieldInfo(Value.Node, .data).type;
 
             while (try seq.nextElement(allocator, Child)) |value| {
                 var node = try allocator.?.create(Value.Node);

--- a/src/de/impls/visitor/tuple.zig
+++ b/src/de/impls/visitor/tuple.zig
@@ -41,7 +41,7 @@ pub fn Visitor(comptime Tuple: type) type {
                     inline while (i < len) : (i += 1) {
                         // NOTE: Using an if to unwrap `value` runs into a
                         // compiler bug, so this is a workaround.
-                        const value = try seq.nextElement(allocator, fields[i].field_type);
+                        const value = try seq.nextElement(allocator, fields[i].type);
                         if (value == null) return error.InvalidLength;
 
                         tuple[i] = value.?;

--- a/src/de/impls/visitor/union.zig
+++ b/src/de/impls/visitor/union.zig
@@ -19,8 +19,8 @@ pub fn Visitor(comptime Union: type) type {
 
             inline for (std.meta.fields(Value)) |f| {
                 if (std.mem.eql(u8, f.name, variant)) {
-                    const alloc = if (f.field_type == void) null else allocator;
-                    return @unionInit(Value, f.name, try va.payload(alloc, f.field_type));
+                    const alloc = if (f.type == void) null else allocator;
+                    return @unionInit(Value, f.name, try va.payload(alloc, f.type));
                 }
             }
 

--- a/src/ser/blocks/struct.zig
+++ b/src/ser/blocks/struct.zig
@@ -25,7 +25,7 @@ pub fn serialize(
     const st = s.structure();
 
     inline for (fields) |field| {
-        if (field.field_type != void) {
+        if (field.type != void) {
             // The name of the field to be deserialized.
             comptime var name: []const u8 = field.name;
 


### PR DESCRIPTION
The struct info in the standard library was updated with a 'field' field.