### PR TITLE
Add support for std.PackedIntArray and std.PackedIntSlice

### DIFF
--- a/src/de/blocks/packed_int_array.zig
+++ b/src/de/blocks/packed_int_array.zig
@@ -1,0 +1,35 @@
+const std = @import("std");
+
+const PackedIntArrayVisitor = @import("../impls/visitor/packed_int_array.zig").Visitor;
+
+/// Specifies all types that can be deserialized by this block.
+pub fn is(
+    /// The type being deserialized into.
+    comptime T: type,
+) bool {
+    return comptime std.mem.startsWith(u8, @typeName(T), "packed_int_array.PackedIntArrayEndian");
+}
+
+/// Specifies the deserialization process for types relevant to this block.
+pub fn deserialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
+    /// The type being deserialized into.
+    comptime T: type,
+    /// A `getty.Deserializer` interface value.
+    deserializer: anytype,
+    /// A `getty.de.Visitor` interface value.
+    visitor: anytype,
+) !@TypeOf(visitor).Value {
+    _ = T;
+
+    return try deserializer.deserializeSeq(allocator, visitor);
+}
+
+/// Returns a type that implements `getty.de.Visitor`.
+pub fn Visitor(
+    /// The type being deserialized into.
+    comptime T: type,
+) type {
+    return PackedIntArrayVisitor(T);
+}

--- a/src/de/impls/visitor/packed_int_array.zig
+++ b/src/de/impls/visitor/packed_int_array.zig
@@ -1,0 +1,44 @@
+const std = @import("std");
+
+const de = @import("../../../de.zig").de;
+
+pub fn Visitor(comptime PackedIntArray: type) type {
+    return struct {
+        const Self = @This();
+
+        pub usingnamespace de.Visitor(
+            Self,
+            Value,
+            .{
+                .visitSeq = visitSeq,
+            },
+        );
+
+        const Value = PackedIntArray;
+
+        fn visitSeq(_: Self, allocator: ?std.mem.Allocator, comptime Deserializer: type, seq: anytype) Deserializer.Error!Value {
+            var array = Value.initAllTo(0);
+
+            if (array.len == 0) {
+                return array;
+            }
+
+            var i: usize = 0;
+            while (i < array.len) : (i += 1) {
+                if (try seq.nextElement(allocator, Value.Child)) |value| {
+                    array.set(i, value);
+                } else {
+                    // End of sequence was reached early.
+                    return error.InvalidLength;
+                }
+            }
+
+            // Expected end of sequence, but found an element.
+            if ((try seq.nextElement(allocator, de.Ignored)) != null) {
+                return error.InvalidLength;
+            }
+
+            return array;
+        }
+    };
+}

--- a/src/ser/blocks/packed_int.zig
+++ b/src/ser/blocks/packed_int.zig
@@ -1,0 +1,32 @@
+const std = @import("std");
+
+/// Specifies all types that can be serialized by this block.
+pub fn is(
+    /// The type of a value being serialized.
+    comptime T: type,
+) bool {
+    comptime {
+        const is_array = std.mem.startsWith(u8, @typeName(T), "packed_int_array.PackedIntArrayEndian");
+        const is_slice = std.mem.startsWith(u8, @typeName(T), "packed_int_array.PackedIntSliceEndian");
+
+        return is_array or is_slice;
+    }
+}
+
+/// Specifies the serialization process for values relevant to this block.
+pub fn serialize(
+    /// A value being serialized.
+    value: anytype,
+    /// A `getty.Serializer` interface value.
+    serializer: anytype,
+) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+    var s = try serializer.serializeSeq(value.len);
+    const seq = s.seq();
+
+    var i: usize = 0;
+    while (i < value.len) : (i += 1) {
+        try seq.serializeElement(value.get(i));
+    }
+
+    return try seq.end();
+}


### PR DESCRIPTION
Support for `std.PackedIntArray` was added for both serialization and deserialization.

However, support for `std.PackedIntSlice` was only added to serialization. I don't think there's a way to make them directly. As an alternative, one can just deserialize into a `std.PackedIntArray` first and then slice into a `std.PackedIntSlice`.