### PR TITLE
ser, de: Move Serializer and Deserializer to getty.zig

### DIFF
--- a/src/de.zig
+++ b/src/de.zig
@@ -2,8 +2,7 @@
 
 const std = @import("std");
 
-/// Deserializer interface.
-pub const Deserializer = @import("de/interfaces/deserializer.zig").Deserializer;
+const Deserializer = @import("de/interfaces/deserializer.zig").Deserializer;
 
 pub const default_dt = .{
     ////////////////////////////////////////////////////////////////////////////

--- a/src/getty.zig
+++ b/src/getty.zig
@@ -7,8 +7,8 @@ const d = @import("de.zig");
 // Types
 ////////////////////////////////////////////////////////////////////////////////
 
-pub const Serializer = s.Serializer;
-pub const Deserializer = d.Deserializer;
+pub const Serializer = @import("ser/interfaces/serializer.zig").Serializer;
+pub const Deserializer = @import("de/interfaces/deserializer.zig").Deserializer;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Namespaces

--- a/src/ser.zig
+++ b/src/ser.zig
@@ -2,8 +2,7 @@
 
 const std = @import("std");
 
-/// Serializer interface.
-pub const Serializer = @import("ser/interfaces/serializer.zig").Serializer;
+const Serializer = @import("ser/interfaces/serializer.zig").Serializer;
 
 pub const default_st = .{
     ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This fixes the documentation for both interfaces in the API reference.