### PR TITLE
de: Do not free string during array deserialization

### DIFF
--- a/src/de/impls/visitor/array.zig
+++ b/src/de/impls/visitor/array.zig
@@ -54,9 +54,7 @@ pub fn Visitor(comptime Array: type) type {
             return array;
         }
 
-        fn visitString(_: Self, allocator: ?std.mem.Allocator, comptime Deserializer: type, input: anytype) Deserializer.Error!Value {
-            defer de.free(allocator.?, input);
-
+        fn visitString(_: Self, _: ?std.mem.Allocator, comptime Deserializer: type, input: anytype) Deserializer.Error!Value {
             if (Child == u8) {
                 var string: Value = undefined;
 


### PR DESCRIPTION
The string is not part of the final value, so the caller should always deallocate it, if it is indeed allocated.