### PR TITLE
de: Test deserialize instead of getty.deserialize

### DIFF
--- a/src/de/blocks/array.zig
+++ b/src/de/blocks/array.zig
@@ -36,12 +36,12 @@ pub fn Visitor(
 }
 
 test "deserialize - array" {
-    try t.de.run(&[_]t.Token{
+    try t.de.run(deserialize, Visitor, &.{
         .{ .Seq = .{ .len = 0 } },
         .{ .SeqEnd = {} },
     }, [_]i32{});
 
-    try t.de.run(&[_]t.Token{
+    try t.de.run(deserialize, Visitor, &.{
         .{ .Seq = .{ .len = 0 } },
         .{ .I32 = 1 },
         .{ .I32 = 2 },
@@ -49,7 +49,7 @@ test "deserialize - array" {
         .{ .SeqEnd = {} },
     }, [3]i32{ 1, 2, 3 });
 
-    try t.de.run(&[_]t.Token{
+    try t.de.run(deserialize, Visitor, &.{
         .{ .Seq = .{ .len = 3 } },
         .{ .Seq = .{ .len = 2 } },
         .{ .I32 = 1 },

--- a/src/de/blocks/array_list.zig
+++ b/src/de/blocks/array_list.zig
@@ -40,7 +40,7 @@ test "deserialize - array list" {
         var expected = std.ArrayList(void).init(std.testing.allocator);
         defer expected.deinit();
 
-        try t.de.run(&[_]t.Token{
+        try t.de.run(deserialize, Visitor, &.{
             .{ .Seq = .{ .len = 0 } },
             .{ .SeqEnd = {} },
         }, expected);
@@ -54,7 +54,7 @@ test "deserialize - array list" {
         try expected.append(2);
         try expected.append(3);
 
-        try t.de.run(&[_]t.Token{
+        try t.de.run(deserialize, Visitor, &.{
             .{ .Seq = .{ .len = 3 } },
             .{ .I8 = 1 },
             .{ .I32 = 2 },
@@ -87,7 +87,7 @@ test "deserialize - array list" {
         try expected.append(b);
         try expected.append(c);
 
-        const tokens = &[_]t.Token{
+        const tokens = &.{
             .{ .Seq = .{ .len = 3 } },
             .{ .Seq = .{ .len = 0 } },
             .{ .SeqEnd = {} },

--- a/src/de/blocks/bool.zig
+++ b/src/de/blocks/bool.zig
@@ -38,6 +38,6 @@ pub fn Visitor(
 }
 
 test "deserialize - bool" {
-    try t.de.run(&[_]t.Token{.{ .Bool = true }}, true);
-    try t.de.run(&[_]t.Token{.{ .Bool = false }}, false);
+    try t.de.run(deserialize, Visitor, &.{.{ .Bool = true }}, true);
+    try t.de.run(deserialize, Visitor, &.{.{ .Bool = false }}, false);
 }

--- a/src/de/blocks/buf_map.zig
+++ b/src/de/blocks/buf_map.zig
@@ -40,7 +40,7 @@ test "deserialize - buf map" {
         var expected = std.BufMap.init(std.testing.allocator);
         defer expected.deinit();
 
-        try t.de.run(&[_]t.Token{
+        try t.de.run(deserialize, Visitor, &.{
             .{ .Map = .{ .len = 0 } },
             .{ .MapEnd = {} },
         }, expected);
@@ -54,7 +54,7 @@ test "deserialize - buf map" {
         try expected.put("two", "bar");
         try expected.put("three", "baz");
 
-        try t.de.run(&[_]t.Token{
+        try t.de.run(deserialize, Visitor, &.{
             .{ .Map = .{ .len = 3 } },
             .{ .String = "one" },
             .{ .String = "foo" },

--- a/src/de/blocks/enum.zig
+++ b/src/de/blocks/enum.zig
@@ -38,12 +38,12 @@ pub fn Visitor(
 test "deserialize - enum" {
     const T = enum { zero, one, two, three, four };
 
-    try t.de.run(&[_]t.Token{ .{ .Enum = {} }, .{ .U8 = 0 } }, T.zero);
-    try t.de.run(&[_]t.Token{ .{ .Enum = {} }, .{ .U16 = 1 } }, T.one);
-    try t.de.run(&[_]t.Token{ .{ .Enum = {} }, .{ .U32 = 2 } }, T.two);
-    try t.de.run(&[_]t.Token{ .{ .Enum = {} }, .{ .U64 = 3 } }, T.three);
-    try t.de.run(&[_]t.Token{ .{ .Enum = {} }, .{ .U128 = 4 } }, T.four);
+    try t.de.run(deserialize, Visitor, &.{ .{ .Enum = {} }, .{ .U8 = 0 } }, T.zero);
+    try t.de.run(deserialize, Visitor, &.{ .{ .Enum = {} }, .{ .U16 = 1 } }, T.one);
+    try t.de.run(deserialize, Visitor, &.{ .{ .Enum = {} }, .{ .U32 = 2 } }, T.two);
+    try t.de.run(deserialize, Visitor, &.{ .{ .Enum = {} }, .{ .U64 = 3 } }, T.three);
+    try t.de.run(deserialize, Visitor, &.{ .{ .Enum = {} }, .{ .U128 = 4 } }, T.four);
 
-    try t.de.run(&[_]t.Token{ .{ .Enum = {} }, .{ .String = "zero" } }, T.zero);
-    try t.de.run(&[_]t.Token{ .{ .Enum = {} }, .{ .String = "four" } }, T.four);
+    try t.de.run(deserialize, Visitor, &.{ .{ .Enum = {} }, .{ .String = "zero" } }, T.zero);
+    try t.de.run(deserialize, Visitor, &.{ .{ .Enum = {} }, .{ .String = "four" } }, T.four);
 }

--- a/src/de/blocks/float.zig
+++ b/src/de/blocks/float.zig
@@ -39,8 +39,8 @@ pub fn Visitor(
 }
 
 test "deserialize - float" {
-    try t.de.run(&[_]t.Token{.{ .F16 = 0 }}, @as(f16, 0));
-    try t.de.run(&[_]t.Token{.{ .F32 = 0 }}, @as(f32, 0));
-    try t.de.run(&[_]t.Token{.{ .F64 = 0 }}, @as(f64, 0));
-    try t.de.run(&[_]t.Token{.{ .F64 = 0 }}, @as(f128, 0));
+    try t.de.run(deserialize, Visitor, &.{.{ .F16 = 0 }}, @as(f16, 0));
+    try t.de.run(deserialize, Visitor, &.{.{ .F32 = 0 }}, @as(f32, 0));
+    try t.de.run(deserialize, Visitor, &.{.{ .F64 = 0 }}, @as(f64, 0));
+    try t.de.run(deserialize, Visitor, &.{.{ .F64 = 0 }}, @as(f128, 0));
 }

--- a/src/de/blocks/int.zig
+++ b/src/de/blocks/int.zig
@@ -40,18 +40,18 @@ pub fn Visitor(
 
 test "deserialize - integer" {
     // signed
-    try t.de.run(&[_]t.Token{.{ .I8 = 0 }}, @as(i8, 0));
-    try t.de.run(&[_]t.Token{.{ .I16 = 0 }}, @as(i16, 0));
-    try t.de.run(&[_]t.Token{.{ .I32 = 0 }}, @as(i32, 0));
-    try t.de.run(&[_]t.Token{.{ .I64 = 0 }}, @as(i64, 0));
-    try t.de.run(&[_]t.Token{.{ .I128 = 0 }}, @as(i128, 0));
-    try t.de.run(&[_]t.Token{.{ .I128 = 0 }}, @as(isize, 0));
+    try t.de.run(deserialize, Visitor, &.{.{ .I8 = 0 }}, @as(i8, 0));
+    try t.de.run(deserialize, Visitor, &.{.{ .I16 = 0 }}, @as(i16, 0));
+    try t.de.run(deserialize, Visitor, &.{.{ .I32 = 0 }}, @as(i32, 0));
+    try t.de.run(deserialize, Visitor, &.{.{ .I64 = 0 }}, @as(i64, 0));
+    try t.de.run(deserialize, Visitor, &.{.{ .I128 = 0 }}, @as(i128, 0));
+    try t.de.run(deserialize, Visitor, &.{.{ .I128 = 0 }}, @as(isize, 0));
 
     // unsigned
-    try t.de.run(&[_]t.Token{.{ .U8 = 0 }}, @as(u8, 0));
-    try t.de.run(&[_]t.Token{.{ .U16 = 0 }}, @as(u16, 0));
-    try t.de.run(&[_]t.Token{.{ .U32 = 0 }}, @as(u32, 0));
-    try t.de.run(&[_]t.Token{.{ .U64 = 0 }}, @as(u64, 0));
-    try t.de.run(&[_]t.Token{.{ .U128 = 0 }}, @as(u128, 0));
-    try t.de.run(&[_]t.Token{.{ .U128 = 0 }}, @as(usize, 0));
+    try t.de.run(deserialize, Visitor, &.{.{ .U8 = 0 }}, @as(u8, 0));
+    try t.de.run(deserialize, Visitor, &.{.{ .U16 = 0 }}, @as(u16, 0));
+    try t.de.run(deserialize, Visitor, &.{.{ .U32 = 0 }}, @as(u32, 0));
+    try t.de.run(deserialize, Visitor, &.{.{ .U64 = 0 }}, @as(u64, 0));
+    try t.de.run(deserialize, Visitor, &.{.{ .U128 = 0 }}, @as(u128, 0));
+    try t.de.run(deserialize, Visitor, &.{.{ .U128 = 0 }}, @as(usize, 0));
 }

--- a/src/de/blocks/linked_list.zig
+++ b/src/de/blocks/linked_list.zig
@@ -39,7 +39,7 @@ test "deserialize - linked list" {
     {
         var expected = std.SinglyLinkedList(i32){};
 
-        try t.de.run(&[_]t.Token{
+        try t.de.run(deserialize, Visitor, &.{
             .{ .Seq = .{ .len = 0 } },
             .{ .SeqEnd = {} },
         }, expected);
@@ -55,7 +55,7 @@ test "deserialize - linked list" {
         one.insertAfter(&two);
         two.insertAfter(&three);
 
-        try t.de.run(&[_]t.Token{
+        try t.de.run(deserialize, Visitor, &.{
             .{ .Seq = .{ .len = 3 } },
             .{ .I32 = 1 },
             .{ .I32 = 2 },
@@ -86,7 +86,7 @@ test "deserialize - linked list" {
         expected.prepend(&Parent.Node{ .data = b });
         expected.prepend(&Parent.Node{ .data = a });
 
-        const tokens = &[_]t.Token{
+        const tokens = &.{
             .{ .Seq = .{ .len = 3 } },
             .{ .Seq = .{ .len = 0 } },
             .{ .SeqEnd = {} },

--- a/src/de/blocks/net_address.zig
+++ b/src/de/blocks/net_address.zig
@@ -46,13 +46,13 @@ test "deserialize - std.net.Address" {
         // IPv4
         {
             var addr = try std.net.Address.resolveIp(ipv4, 0);
-            try t.de.run(&[_]t.Token{.{ .String = ipv4 ++ ":0" }}, addr);
+            try t.de.run(deserialize, Visitor, &.{.{ .String = ipv4 ++ ":0" }}, addr);
         }
 
         // IPv6
         {
             var addr = try std.net.Address.resolveIp(ipv6, 80);
-            try t.de.run(&[_]t.Token{.{ .String = ipv6_wrapped ++ ":80" }}, addr);
+            try t.de.run(deserialize, Visitor, &.{.{ .String = ipv6_wrapped ++ ":80" }}, addr);
         }
     }
 }

--- a/src/de/blocks/optional.zig
+++ b/src/de/blocks/optional.zig
@@ -36,6 +36,6 @@ pub fn Visitor(
 }
 
 test "deserialize - optional" {
-    try t.de.run(&[_]t.Token{.{ .Null = {} }}, @as(?i32, null));
-    try t.de.run(&[_]t.Token{ .{ .Some = {} }, .{ .I32 = 0 } }, @as(?i32, 0));
+    try t.de.run(deserialize, Visitor, &.{.{ .Null = {} }}, @as(?i32, null));
+    try t.de.run(deserialize, Visitor, &.{ .{ .Some = {} }, .{ .I32 = 0 } }, @as(?i32, 0));
 }

--- a/src/de/blocks/packed_int_array.zig
+++ b/src/de/blocks/packed_int_array.zig
@@ -39,7 +39,7 @@ test "deserialize - std.PackedIntArray" {
     {
         var expected = std.PackedIntArray(u32, 0).init([0]u32{});
 
-        try t.de.run(&[_]t.Token{
+        try t.de.run(deserialize, Visitor, &.{
             .{ .Seq = .{ .len = 0 } },
             .{ .SeqEnd = {} },
         }, expected);
@@ -48,7 +48,7 @@ test "deserialize - std.PackedIntArray" {
     {
         var expected = std.PackedIntArray(u32, 3).init([3]u32{ 1, 1, 1 });
 
-        try t.de.run(&[_]t.Token{
+        try t.de.run(deserialize, Visitor, &.{
             .{ .Seq = .{ .len = 3 } },
             .{ .I32 = 1 },
             .{ .I32 = 1 },
@@ -60,7 +60,7 @@ test "deserialize - std.PackedIntArray" {
     {
         var expected = std.PackedIntArray(i32, 3).initAllTo(-1);
 
-        try t.de.run(&[_]t.Token{
+        try t.de.run(deserialize, Visitor, &.{
             .{ .Seq = .{ .len = 3 } },
             .{ .I32 = -1 },
             .{ .I32 = -1 },

--- a/src/de/blocks/pointer.zig
+++ b/src/de/blocks/pointer.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const t = @import("getty/testing");
 
 const de = @import("../de.zig");
 
@@ -35,4 +36,68 @@ pub fn deserialize(
     const db = de.de.find_db(@TypeOf(deserializer), Child);
 
     return try db.deserialize(allocator, Child, deserializer, visitor);
+}
+
+test "deserialize - pointer, string" {
+    // No sentinel
+    {
+        // *[N]u8
+        {
+            var arr = [3]u8{ 'a', 'b', 'c' };
+
+            try t.de.run(deserialize, Visitor, &.{.{ .String = "abc" }}, &arr);
+            try t.de.run(deserialize, Visitor, &.{
+                .{ .Seq = .{ .len = 3 } },
+                .{ .U8 = 'a' },
+                .{ .U8 = 'b' },
+                .{ .U8 = 'c' },
+                .{ .SeqEnd = {} },
+            }, &arr);
+        }
+
+        // *const [N]u8
+        {
+            const arr = [3]u8{ 'a', 'b', 'c' };
+
+            try t.de.run(deserialize, Visitor, &.{.{ .String = "abc" }}, &arr);
+            try t.de.run(deserialize, Visitor, &.{
+                .{ .Seq = .{ .len = 3 } },
+                .{ .U8 = 'a' },
+                .{ .U8 = 'b' },
+                .{ .U8 = 'c' },
+                .{ .SeqEnd = {} },
+            }, &arr);
+        }
+    }
+
+    // Sentinel
+    {
+        // *[N:S]u8
+        {
+            var arr = [3:0]u8{ 'a', 'b', 'c' };
+
+            try t.de.run(deserialize, Visitor, &.{.{ .String = "abc" }}, &arr);
+            try t.de.run(deserialize, Visitor, &.{
+                .{ .Seq = .{ .len = 3 } },
+                .{ .U8 = 'a' },
+                .{ .U8 = 'b' },
+                .{ .U8 = 'c' },
+                .{ .SeqEnd = {} },
+            }, &arr);
+        }
+
+        // *const [N:S]u8
+        {
+            const arr = [3:0]u8{ 'a', 'b', 'c' };
+
+            try t.de.run(deserialize, Visitor, &.{.{ .String = "abc" }}, &arr);
+            try t.de.run(deserialize, Visitor, &.{
+                .{ .Seq = .{ .len = 3 } },
+                .{ .U8 = 'a' },
+                .{ .U8 = 'b' },
+                .{ .U8 = 'c' },
+                .{ .SeqEnd = {} },
+            }, &arr);
+        }
+    }
 }

--- a/src/de/blocks/slice.zig
+++ b/src/de/blocks/slice.zig
@@ -36,36 +36,20 @@ pub fn Visitor(
     return SliceVisitor(T);
 }
 
-test "deserialize - string" {
+test "deserialize - slice, string" {
+    // No sentinel
     {
         var arr = [_]u8{ 'a', 'b', 'c' };
 
-        // No sentinel
-        try t.de.run(&[_]t.Token{
-            .{ .Seq = .{ .len = 3 } },
-            .{ .U8 = 'a' },
-            .{ .U8 = 'b' },
-            .{ .U8 = 'c' },
-            .{ .SeqEnd = {} },
-        }, "abc");
-
-        try t.de.run(&[_]t.Token{.{ .String = "abc" }}, @as([]u8, &arr));
-        try t.de.run(&[_]t.Token{.{ .String = "abc" }}, @as([]const u8, &arr));
+        try t.de.run(deserialize, Visitor, &.{.{ .String = "abc" }}, @as([]u8, &arr));
+        try t.de.run(deserialize, Visitor, &.{.{ .String = "abc" }}, @as([]const u8, &arr));
     }
 
+    // Sentinel
     {
         var arr = [_:0]u8{ 'a', 'b', 'c' };
 
-        // Sentinel
-        try t.de.run(&[_]t.Token{
-            .{ .Seq = .{ .len = 3 } },
-            .{ .U8 = 'a' },
-            .{ .U8 = 'b' },
-            .{ .U8 = 'c' },
-            .{ .SeqEnd = {} },
-        }, "abc");
-
-        try t.de.run(&[_]t.Token{.{ .String = "abc" }}, @as([:0]u8, &arr));
-        try t.de.run(&[_]t.Token{.{ .String = "abc" }}, @as([:0]const u8, &arr));
+        try t.de.run(deserialize, Visitor, &.{.{ .String = "abc" }}, @as([:0]u8, &arr));
+        try t.de.run(deserialize, Visitor, &.{.{ .String = "abc" }}, @as([:0]const u8, &arr));
     }
 }

--- a/src/de/blocks/struct.zig
+++ b/src/de/blocks/struct.zig
@@ -36,14 +36,14 @@ pub fn Visitor(
 }
 
 test "deserialize - struct" {
-    try t.de.run(&[_]t.Token{
+    try t.de.run(deserialize, Visitor, &.{
         .{ .Struct = .{ .name = "", .len = 0 } },
         .{ .StructEnd = {} },
     }, struct {}{});
 
     const T = struct { a: i32, b: i32, c: i32 };
 
-    try t.de.run(&[_]t.Token{
+    try t.de.run(deserialize, Visitor, &.{
         .{ .Struct = .{ .name = "T", .len = 3 } },
         .{ .String = "a" },
         .{ .I32 = 1 },

--- a/src/de/blocks/tail_queue.zig
+++ b/src/de/blocks/tail_queue.zig
@@ -39,7 +39,7 @@ test "deserialize - tail queue" {
     {
         var expected = std.TailQueue(i32){};
 
-        try t.de.run(&[_]t.Token{
+        try t.de.run(deserialize, Visitor, &.{
             .{ .Seq = .{ .len = 0 } },
             .{ .SeqEnd = {} },
         }, expected);
@@ -55,7 +55,7 @@ test "deserialize - tail queue" {
         expected.append(&two);
         expected.append(&three);
 
-        try t.de.run(&[_]t.Token{
+        try t.de.run(deserialize, Visitor, &.{
             .{ .Seq = .{ .len = 3 } },
             .{ .I32 = 1 },
             .{ .I32 = 2 },
@@ -86,7 +86,7 @@ test "deserialize - tail queue" {
         expected.append(&Parent.Node{ .data = b });
         expected.append(&Parent.Node{ .data = c });
 
-        const tokens = &[_]t.Token{
+        const tokens = &.{
             .{ .Seq = .{ .len = 3 } },
             .{ .Seq = .{ .len = 0 } },
             .{ .SeqEnd = {} },

--- a/src/de/blocks/tuple.zig
+++ b/src/de/blocks/tuple.zig
@@ -36,14 +36,14 @@ pub fn Visitor(
 }
 
 test "deserialize - tuple" {
-    try t.de.run(&[_]t.Token{
+    try t.de.run(deserialize, Visitor, &.{
         .{ .Seq = .{ .len = 2 } },
         .{ .I32 = 1 },
         .{ .U32 = 2 },
         .{ .SeqEnd = {} },
     }, std.meta.Tuple(&[_]type{ i32, u32 }){ 1, 2 });
 
-    //try t.de.run(&[_]t.Token{
+    //try t.de.run(deserialize, Visitor, &.{
     //.{ .Seq = .{ .len = 3 } },
     //.{ .Seq = .{ .len = 2 } },
     //.{ .I32 = 1 },

--- a/src/de/blocks/union.zig
+++ b/src/de/blocks/union.zig
@@ -43,12 +43,12 @@ test "deserialize - union" {
             bar: void,
         };
 
-        try t.de.run(&[_]t.Token{
+        try t.de.run(deserialize, Visitor, &.{
             .{ .Union = {} },
             .{ .String = "foo" },
             .{ .Bool = true },
         }, T{ .foo = true });
-        try t.de.run(&[_]t.Token{
+        try t.de.run(deserialize, Visitor, &.{
             .{ .Union = {} },
             .{ .String = "bar" },
             .{ .Void = {} },
@@ -65,7 +65,7 @@ test "deserialize - union" {
         };
 
         {
-            const tokens = &[_]t.Token{
+            const tokens = &.{
                 .{ .Union = {} },
                 .{ .String = "foo" },
                 .{ .Bool = true },
@@ -78,7 +78,7 @@ test "deserialize - union" {
         }
 
         {
-            const tokens = &[_]t.Token{
+            const tokens = &.{
                 .{ .Union = {} },
                 .{ .String = "bar" },
                 .{ .Void = {} },

--- a/src/de/blocks/void.zig
+++ b/src/de/blocks/void.zig
@@ -38,5 +38,5 @@ pub fn Visitor(
 }
 
 test "deserialize - void" {
-    try t.de.run(&[_]t.Token{.{ .Void = {} }}, {});
+    try t.de.run(deserialize, Visitor, &.{.{ .Void = {} }}, {});
 }


### PR DESCRIPTION
One pointer (string) tests have been moved/added to the pointer block. Some of those tests were incorrectly in the slice block.