### PR TITLE
ser: Take an optional allocator in SBs

### DIFF
--- a/src/ser/blocks/allocator.zig
+++ b/src/ser/blocks/allocator.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+
 const t = @import("../testing.zig");
 
 /// Specifies all types that can be serialized by this block.
@@ -11,10 +12,14 @@ pub fn is(
 
 /// Specifies the serialization process for values relevant to this block.
 pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
     /// A value being serialized.
     value: anytype,
     /// A `getty.Serializer` interface value.
     serializer: anytype,
 ) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+    _ = allocator;
+
     @compileError("type is not supported: " ++ @typeName(@TypeOf(value)));
 }

--- a/src/ser/blocks/array.zig
+++ b/src/ser/blocks/array.zig
@@ -1,3 +1,5 @@
+const std = @import("std");
+
 const t = @import("../testing.zig");
 
 /// Specifies all types that can be serialized by this block.
@@ -10,11 +12,15 @@ pub fn is(
 
 /// Specifies the serialization process for values relevant to this block.
 pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
     /// A value being serialized.
     value: anytype,
     /// A `getty.Serializer` interface value.
     serializer: anytype,
 ) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+    _ = allocator;
+
     var s = try serializer.serializeSeq(value.len);
     const seq = s.seq();
     for (value) |elem| {

--- a/src/ser/blocks/array_list.zig
+++ b/src/ser/blocks/array_list.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+
 const t = @import("../testing.zig");
 
 /// Specifies all types that can be serialized by this block.
@@ -11,11 +12,15 @@ pub fn is(
 
 /// Specifies the serialization process for values relevant to this block.
 pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
     /// A value being serialized.
     value: anytype,
     /// A `getty.Serializer` interface value.
     serializer: anytype,
 ) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+    _ = allocator;
+
     var s = try serializer.serializeSeq(value.items.len);
     const seq = s.seq();
     for (value.items) |elem| {

--- a/src/ser/blocks/bool.zig
+++ b/src/ser/blocks/bool.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+
 const t = @import("../testing.zig");
 
 /// Specifies all types that can be serialized by this block.
@@ -11,11 +12,15 @@ pub fn is(
 
 /// Specifies the serialization process for values relevant to this block.
 pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
     /// A value being serialized.
     value: anytype,
     /// A `getty.Serializer` interface value.
     serializer: anytype,
 ) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+    _ = allocator;
+
     return try serializer.serializeBool(value);
 }
 

--- a/src/ser/blocks/bounded_array.zig
+++ b/src/ser/blocks/bounded_array.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+
 const t = @import("../testing.zig");
 
 /// Specifies all types that can be serialized by this block.
@@ -11,11 +12,15 @@ pub fn is(
 
 /// Specifies the serialization process for values relevant to this block.
 pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
     /// A value being serialized.
     value: anytype,
     /// A `getty.Serializer` interface value.
     serializer: anytype,
 ) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+    _ = allocator;
+
     var s = try serializer.serializeSeq(value.len);
     const seq = s.seq();
     for (value.constSlice()) |elem| {

--- a/src/ser/blocks/buf_map.zig
+++ b/src/ser/blocks/buf_map.zig
@@ -13,12 +13,14 @@ pub fn is(
 
 /// Specifies the serialization process for values relevant to this block.
 pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
     /// A value being serialized.
     value: anytype,
     /// A `getty.Serializer` interface value.
     serializer: anytype,
 ) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
-    return try getty_serialize(value.hash_map, serializer);
+    return try getty_serialize(allocator, value.hash_map, serializer);
 }
 
 test "serialize - buf map" {

--- a/src/ser/blocks/enum.zig
+++ b/src/ser/blocks/enum.zig
@@ -1,3 +1,5 @@
+const std = @import("std");
+
 const t = @import("../testing.zig");
 
 /// Specifies all types that can be serialized by this block.
@@ -13,11 +15,15 @@ pub fn is(
 
 /// Specifies the serialization process for values relevant to this block.
 pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
     /// A value being serialized.
     value: anytype,
     /// A `getty.Serializer` interface value.
     serializer: anytype,
 ) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+    _ = allocator;
+
     return try serializer.serializeEnum(value);
 }
 

--- a/src/ser/blocks/error.zig
+++ b/src/ser/blocks/error.zig
@@ -1,3 +1,5 @@
+const std = @import("std");
+
 const getty_serialize = @import("../serialize.zig").serialize;
 const t = @import("../testing.zig");
 
@@ -11,12 +13,15 @@ pub fn is(
 
 /// Specifies the serialization process for values relevant to this block.
 pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
     /// A value being serialized.
     value: anytype,
     /// A `getty.Serializer` interface value.
     serializer: anytype,
 ) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
-    return try getty_serialize(@as([]const u8, @errorName(value)), serializer);
+    const String = []const u8;
+    return try getty_serialize(allocator, @as(String, @errorName(value)), serializer);
 }
 
 test "serialize - error" {

--- a/src/ser/blocks/float.zig
+++ b/src/ser/blocks/float.zig
@@ -1,3 +1,5 @@
+const std = @import("std");
+
 const t = @import("../testing.zig");
 
 /// Specifies all types that can be serialized by this block.
@@ -13,11 +15,15 @@ pub fn is(
 
 /// Specifies the serialization process for values relevant to this block.
 pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
     /// A value being serialized.
     value: anytype,
     /// A `getty.Serializer` interface value.
     serializer: anytype,
 ) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+    _ = allocator;
+
     return try serializer.serializeFloat(value);
 }
 

--- a/src/ser/blocks/hash_map.zig
+++ b/src/ser/blocks/hash_map.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+
 const t = @import("../testing.zig");
 
 /// Specifies all types that can be serialized by this block.
@@ -14,11 +15,15 @@ pub fn is(
 
 /// Specifies the serialization process for values relevant to this block.
 pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
     /// A value being serialized.
     value: anytype,
     /// A `getty.Serializer` interface value.
     serializer: anytype,
 ) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+    _ = allocator;
+
     var m = try serializer.serializeMap(value.count());
     const map = m.map();
     {

--- a/src/ser/blocks/int.zig
+++ b/src/ser/blocks/int.zig
@@ -1,3 +1,5 @@
+const std = @import("std");
+
 const t = @import("../testing.zig");
 
 /// Specifies all types that can be serialized by this block.
@@ -13,11 +15,15 @@ pub fn is(
 
 /// Specifies the serialization process for values relevant to this block.
 pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
     /// A value being serialized.
     value: anytype,
     /// A `getty.Serializer` interface value.
     serializer: anytype,
 ) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+    _ = allocator;
+
     return try serializer.serializeInt(value);
 }
 

--- a/src/ser/blocks/linked_list.zig
+++ b/src/ser/blocks/linked_list.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+
 const t = @import("../testing.zig");
 
 /// Specifies all types that can be serialized by this block.
@@ -11,11 +12,15 @@ pub fn is(
 
 /// Specifies the serialization process for values relevant to this block.
 pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
     /// A value being serialized.
     value: anytype,
     /// A `getty.Serializer` interface value.
     serializer: anytype,
 ) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+    _ = allocator;
+
     var s = try serializer.serializeSeq(value.len());
     const seq = s.seq();
     {

--- a/src/ser/blocks/multi_array_list.zig
+++ b/src/ser/blocks/multi_array_list.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+
 const t = @import("../testing.zig");
 
 /// Specifies all types that can be serialized by this block.
@@ -11,11 +12,15 @@ pub fn is(
 
 /// Specifies the serialization process for values relevant to this block.
 pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
     /// A value being serialized.
     value: anytype,
     /// A `getty.Serializer` interface value.
     serializer: anytype,
 ) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+    _ = allocator;
+
     var s = try serializer.serializeSeq(value.len);
     const seq = s.seq();
 

--- a/src/ser/blocks/net_address.zig
+++ b/src/ser/blocks/net_address.zig
@@ -1,5 +1,6 @@
 const builtin = @import("builtin");
 const std = @import("std");
+
 const t = @import("../testing.zig");
 
 // The maximum number of characters in an IPv6 address.
@@ -29,11 +30,15 @@ pub fn is(
 
 /// Specifies the serialization process for values relevant to this block.
 pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
     /// A value being serialized.
     value: anytype,
     /// A `getty.Serializer` interface value.
     serializer: anytype,
 ) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+    _ = allocator;
+
     var arr = [_]u8{0} ** (max_ipv6_chars + max_port_chars);
 
     // UNREACHABLE: With the size values used in the array's declaration, there

--- a/src/ser/blocks/null.zig
+++ b/src/ser/blocks/null.zig
@@ -1,3 +1,5 @@
+const std = @import("std");
+
 const t = @import("../testing.zig");
 
 /// Specifies all types that can be serialized by this block.
@@ -10,11 +12,14 @@ pub fn is(
 
 /// Specifies the serialization process for values relevant to this block.
 pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
     /// A value being serialized.
     value: anytype,
     /// A `getty.Serializer` interface value.
     serializer: anytype,
 ) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+    _ = allocator;
     _ = value;
 
     return try serializer.serializeNull();

--- a/src/ser/blocks/optional.zig
+++ b/src/ser/blocks/optional.zig
@@ -1,3 +1,5 @@
+const std = @import("std");
+
 const t = @import("../testing.zig");
 
 /// Specifies all types that can be serialized by this block.
@@ -10,11 +12,15 @@ pub fn is(
 
 /// Specifies the serialization process for values relevant to this block.
 pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
     /// A value being serialized.
     value: anytype,
     /// A `getty.Serializer` interface value.
     serializer: anytype,
 ) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+    _ = allocator;
+
     return try if (value) |v| serializer.serializeSome(v) else serializer.serializeNull();
 }
 

--- a/src/ser/blocks/packed_int.zig
+++ b/src/ser/blocks/packed_int.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+
 const t = @import("../testing.zig");
 
 /// Specifies all types that can be serialized by this block.
@@ -16,11 +17,15 @@ pub fn is(
 
 /// Specifies the serialization process for values relevant to this block.
 pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
     /// A value being serialized.
     value: anytype,
     /// A `getty.Serializer` interface value.
     serializer: anytype,
 ) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+    _ = allocator;
+
     var s = try serializer.serializeSeq(value.len);
     const seq = s.seq();
 

--- a/src/ser/blocks/pointer.zig
+++ b/src/ser/blocks/pointer.zig
@@ -13,6 +13,8 @@ pub fn is(
 
 /// Specifies the serialization process for values relevant to this block.
 pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
     /// A value being serialized.
     value: anytype,
     /// A `getty.Serializer` interface value.
@@ -22,10 +24,11 @@ pub fn serialize(
 
     // Serialize array pointers as slices so that strings are handled properly.
     if (@typeInfo(info.child) == .Array) {
-        return try getty_serialize(@as([]const std.meta.Elem(info.child), value), serializer);
+        const Slice = []const std.meta.Elem(info.child);
+        return try getty_serialize(allocator, @as(Slice, value), serializer);
     }
 
-    return try getty_serialize(value.*, serializer);
+    return try getty_serialize(allocator, value.*, serializer);
 }
 
 test "serialize - pointer" {

--- a/src/ser/blocks/slice.zig
+++ b/src/ser/blocks/slice.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+
 const t = @import("../testing.zig");
 
 /// Specifies all types that can be serialized by this block.
@@ -11,11 +12,15 @@ pub fn is(
 
 /// Specifies the serialization process for values relevant to this block.
 pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
     /// A value being serialized.
     value: anytype,
     /// A `getty.Serializer` interface value.
     serializer: anytype,
 ) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+    _ = allocator;
+
     var s = try serializer.serializeSeq(value.len);
     const seq = s.seq();
     for (value) |elem| {

--- a/src/ser/blocks/string.zig
+++ b/src/ser/blocks/string.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+
 const t = @import("../testing.zig");
 
 /// Specifies all types that can be serialized by this block.
@@ -11,11 +12,15 @@ pub fn is(
 
 /// Specifies the serialization process for values relevant to this block.
 pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
     /// A value being serialized.
     value: anytype,
     /// A `getty.Serializer` interface value.
     serializer: anytype,
 ) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+    _ = allocator;
+
     return try serializer.serializeString(value);
 }
 

--- a/src/ser/blocks/struct.zig
+++ b/src/ser/blocks/struct.zig
@@ -13,11 +13,15 @@ pub fn is(
 
 /// Specifies the serialization process for values relevant to this block.
 pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
     /// A value being serialized.
     value: anytype,
     /// A `getty.Serializer` interface value.
     serializer: anytype,
 ) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+    _ = allocator;
+
     const T = @TypeOf(value);
     const fields = std.meta.fields(T);
     const attributes = comptime getAttributes(T, @TypeOf(serializer));

--- a/src/ser/blocks/tail_queue.zig
+++ b/src/ser/blocks/tail_queue.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+
 const t = @import("../testing.zig");
 
 /// Specifies all types that can be serialized by this block.
@@ -11,11 +12,15 @@ pub fn is(
 
 /// Specifies the serialization process for values relevant to this block.
 pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
     /// A value being serialized.
     value: anytype,
     /// A `getty.Serializer` interface value.
     serializer: anytype,
 ) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+    _ = allocator;
+
     var s = try serializer.serializeSeq(value.len);
     const seq = s.seq();
     {

--- a/src/ser/blocks/tuple.zig
+++ b/src/ser/blocks/tuple.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+
 const t = @import("../testing.zig");
 
 /// Specifies all types that can be serialized by this block.
@@ -11,11 +12,15 @@ pub fn is(
 
 /// Specifies the serialization process for values relevant to this block.
 pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
     /// A value being serialized.
     value: anytype,
     /// A `getty.Serializer` interface value.
     serializer: anytype,
 ) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+    _ = allocator;
+
     const T = @TypeOf(value);
 
     var s = try serializer.serializeSeq(std.meta.fields(T).len);

--- a/src/ser/blocks/union.zig
+++ b/src/ser/blocks/union.zig
@@ -13,11 +13,15 @@ pub fn is(
 
 /// Specifies the serialization process for values relevant to this block.
 pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
     /// A value being serialized.
     value: anytype,
     /// A `getty.Serializer` interface value.
     serializer: anytype,
 ) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+    _ = allocator;
+
     const T = @TypeOf(value);
     const info = @typeInfo(T).Union;
     const attributes = comptime getAttributes(T, @TypeOf(serializer));

--- a/src/ser/blocks/vector.zig
+++ b/src/ser/blocks/vector.zig
@@ -1,3 +1,5 @@
+const std = @import("std");
+
 const getty_serialize = @import("../serialize.zig").serialize;
 const t = @import("../testing.zig");
 
@@ -11,6 +13,8 @@ pub fn is(
 
 /// Specifies the serialization process for values relevant to this block.
 pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
     /// A value being serialized.
     value: anytype,
     /// A `getty.Serializer` interface value.
@@ -18,7 +22,8 @@ pub fn serialize(
 ) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
     const info = @typeInfo(@TypeOf(value)).Vector;
 
-    return try getty_serialize(@as([info.len]info.child, value), serializer);
+    const Array = [info.len]info.child;
+    return try getty_serialize(allocator, @as(Array, value), serializer);
 }
 
 test "serialize - vector" {

--- a/src/ser/blocks/void.zig
+++ b/src/ser/blocks/void.zig
@@ -1,3 +1,5 @@
+const std = @import("std");
+
 const t = @import("../testing.zig");
 
 /// Specifies all types that can be serialized by this block.
@@ -10,11 +12,14 @@ pub fn is(
 
 /// Specifies the serialization process for values relevant to this block.
 pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
     /// A value being serialized.
     value: anytype,
     /// A `getty.Serializer` interface value.
     serializer: anytype,
 ) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+    _ = allocator;
     _ = value;
 
     return try serializer.serializeVoid();

--- a/src/ser/serialize.zig
+++ b/src/ser/serialize.zig
@@ -9,6 +9,8 @@ const traits = @import("traits.zig");
 
 /// Serializes a value into a `getty.Serializer`.
 pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
     /// A value to serialize.
     value: anytype,
     /// A `getty.Serializer` interface value.
@@ -53,13 +55,13 @@ pub fn serialize(
     // Process attributes, if any exist.
     if (comptime traits.has_attributes(T, block)) {
         switch (@typeInfo(T)) {
-            .Struct => return try blocks.Struct.serialize(value, serializer),
-            .Union => return try blocks.Union.serialize(value, serializer),
+            .Struct => return try blocks.Struct.serialize(allocator, value, serializer),
+            .Union => return try blocks.Union.serialize(allocator, value, serializer),
             else => @compileError("unexpected type cannot be serialized using attributes"),
         }
     }
 
-    return try block.serialize(value, serializer);
+    return try block.serialize(allocator, value, serializer);
 }
 
 test "serialize - success, normal" {
@@ -72,7 +74,7 @@ test "serialize - success, normal" {
         y: i32,
 
         pub const @"getty.sb" = struct {
-            pub fn serialize(value: anytype, serializer: anytype) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+            pub fn serialize(_: ?std.mem.Allocator, value: anytype, serializer: anytype) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
                 var s = try serializer.serializeSeq(2);
                 const seq = s.seq();
 
@@ -89,7 +91,7 @@ test "serialize - success, normal" {
             return T == Point;
         }
 
-        pub fn serialize(value: anytype, serializer: anytype) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+        pub fn serialize(_: ?std.mem.Allocator, value: anytype, serializer: anytype) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
             var s = try serializer.serializeSeq(2);
             const seq = s.seq();
 
@@ -115,7 +117,7 @@ test "serialize - success, normal" {
             .{ .StructEnd = {} },
         });
 
-        serialize(v, s.serializer()) catch return error.UnexpectedTestError;
+        serialize(null, v, s.serializer()) catch return error.UnexpectedTestError;
         try expectEqual(expected, s.remaining());
     }
 
@@ -128,7 +130,7 @@ test "serialize - success, normal" {
             .{ .SeqEnd = {} },
         });
 
-        serialize(v, s.serializer()) catch return error.UnexpectedTestError;
+        serialize(null, v, s.serializer()) catch return error.UnexpectedTestError;
         try expectEqual(expected, s.remaining());
     }
 
@@ -141,7 +143,7 @@ test "serialize - success, normal" {
             .{ .SeqEnd = {} },
         });
 
-        serialize(v, s.serializer()) catch return error.UnexpectedTestError;
+        serialize(null, v, s.serializer()) catch return error.UnexpectedTestError;
         try expectEqual(expected, s.remaining());
     }
 
@@ -154,7 +156,7 @@ test "serialize - success, normal" {
             .{ .SeqEnd = {} },
         });
 
-        serialize(v_attrs, s.serializer()) catch return error.UnexpectedTestError;
+        serialize(null, v_attrs, s.serializer()) catch return error.UnexpectedTestError;
         try expectEqual(expected, s.remaining());
     }
 }
@@ -199,7 +201,7 @@ test "serialize - success, attributes" {
             .{ .StructEnd = {} },
         });
 
-        serialize(v, s.serializer()) catch return error.UnexpectedTestError;
+        serialize(null, v, s.serializer()) catch return error.UnexpectedTestError;
         try expectEqual(expected, s.remaining());
     }
 
@@ -212,7 +214,7 @@ test "serialize - success, attributes" {
             .{ .StructEnd = {} },
         });
 
-        serialize(v, s.serializer()) catch return error.UnexpectedTestError;
+        serialize(null, v, s.serializer()) catch return error.UnexpectedTestError;
         try expectEqual(expected, s.remaining());
     }
 
@@ -225,7 +227,7 @@ test "serialize - success, attributes" {
             .{ .StructEnd = {} },
         });
 
-        serialize(v_attrs, s.serializer()) catch return error.UnexpectedTestError;
+        serialize(null, v_attrs, s.serializer()) catch return error.UnexpectedTestError;
         try expectEqual(expected, s.remaining());
     }
 }
@@ -281,7 +283,7 @@ test "serialize - priority" {
             .{ .StructEnd = {} },
         });
 
-        serialize(v, s.serializer()) catch return error.UnexpectedTestError;
+        serialize(null, v, s.serializer()) catch return error.UnexpectedTestError;
         try expectEqual(expected, s.remaining());
     }
 
@@ -304,7 +306,7 @@ test "serialize - priority" {
             .{ .StructEnd = {} },
         });
 
-        serialize(v, s.serializer()) catch return error.UnexpectedTestError;
+        serialize(null, v, s.serializer()) catch return error.UnexpectedTestError;
         try expectEqual(expected, s.remaining());
     }
 
@@ -327,7 +329,7 @@ test "serialize - priority" {
             .{ .StructEnd = {} },
         });
 
-        serialize(v, s.serializer()) catch return error.UnexpectedTestError;
+        serialize(null, v, s.serializer()) catch return error.UnexpectedTestError;
         try expectEqual(expected, s.remaining());
     }
 }


### PR DESCRIPTION
This allows the serialize function in SBs to allocate if necessary. For example, serializing SemanticVersion values as strings requires allocation since they can be arbitrarily long.