### PR TITLE
de: Set evaluation branch quota

### DIFF
--- a/src/de/impls/visitor/enum.zig
+++ b/src/de/impls/visitor/enum.zig
@@ -24,6 +24,8 @@ pub fn Visitor(comptime Enum: type) type {
         }
 
         fn visitInt(_: Self, _: ?std.mem.Allocator, comptime Deserializer: type, input: anytype) Deserializer.Error!Value {
+            @setEvalBranchQuota(10_000);
+
             const fields = std.meta.fields(Value);
             const attributes = comptime getAttributes(Value, Deserializer);
             const result = std.meta.intToEnum(Value, input) catch return error.InvalidValue;
@@ -51,6 +53,8 @@ pub fn Visitor(comptime Enum: type) type {
         }
 
         fn visitString(_: Self, _: ?std.mem.Allocator, comptime Deserializer: type, input: anytype) Deserializer.Error!Value {
+            @setEvalBranchQuota(10_000);
+
             const fields = std.meta.fields(Value);
             const attributes = comptime getAttributes(Value, Deserializer);
 

--- a/src/de/impls/visitor/struct.zig
+++ b/src/de/impls/visitor/struct.zig
@@ -18,6 +18,8 @@ pub fn Visitor(comptime Struct: type) type {
         const Value = Struct;
 
         fn visitMap(_: Self, allocator: ?std.mem.Allocator, comptime Deserializer: type, map: anytype) Deserializer.Error!Value {
+            @setEvalBranchQuota(10_000);
+
             const fields = comptime std.meta.fields(Value);
             const attributes = comptime getAttributes(Value, Deserializer);
 

--- a/src/de/impls/visitor/tuple.zig
+++ b/src/de/impls/visitor/tuple.zig
@@ -17,6 +17,8 @@ pub fn Visitor(comptime Tuple: type) type {
         const Value = Tuple;
 
         fn visitSeq(_: Self, allocator: ?std.mem.Allocator, comptime Deserializer: type, seq: anytype) Deserializer.Error!Value {
+            @setEvalBranchQuota(10_000);
+
             const fields = std.meta.fields(Value);
             const len = fields.len;
 

--- a/src/de/impls/visitor/union.zig
+++ b/src/de/impls/visitor/union.zig
@@ -16,6 +16,8 @@ pub fn Visitor(comptime Union: type) type {
         const Value = Union;
 
         fn visitUnion(_: Self, allocator: ?std.mem.Allocator, comptime Deserializer: type, ua: anytype, va: anytype) Deserializer.Error!Value {
+            @setEvalBranchQuota(10_000);
+
             const attributes = comptime getAttributes(Value, Deserializer);
 
             var variant = try ua.variant(allocator, []const u8);


### PR DESCRIPTION
Setting the quota based on the number of fields didn't work out. The formula I used was `1000 + (fields.len * 2) + (fields.len * fields.len)`. That got me close to the actual quota I needed but there was some extra branches that I couldn't account for. So, I decided instead to do away with the half-working solution and just set a nice large arbitrary quota.

Considering how #103 only needs 1,708 branches, the quota of 10,000 seems reasonable to me.

Closes #103.