### PR TITLE
de: Temporarily disable std.net.Address support

### DIFF
--- a/src/de/tuples.zig
+++ b/src/de/tuples.zig
@@ -54,7 +54,7 @@ pub const default = .{
 
     blocks.IntegerBitSet,
     //blocks.MultiArrayList,
-    blocks.NetAddress,
+    //blocks.NetAddress,
 
     // Covers the following types:
     //


### PR DESCRIPTION
It's broken for aarch64 now too ;-;. Zig why