### PR TITLE
Make examples run again

### DIFF
--- a/examples/bool-deserializer/main.zig
+++ b/examples/bool-deserializer/main.zig
@@ -1,42 +1,58 @@
 const std = @import("std");
 const getty = @import("getty");
 
-const Deserializer = struct {
-    tokens: std.json.TokenStream,
+const BUF_SIZE = 1024;
 
-    const Self = @This();
+fn Deserializer(comptime Reader: type) type {
+    const JsonReader = std.json.Reader(BUF_SIZE, Reader);
 
-    pub usingnamespace getty.Deserializer(
-        *Self,
-        Error,
-        null,
-        null,
-        .{
-            .deserializeBool = deserializeBool,
-        },
-    );
+    return struct {
+        tokens: JsonReader,
 
-    const Error = getty.de.Error || std.json.TokenStream.Error;
+        const Self = @This();
 
-    const De = Self.@"getty.Deserializer";
+        pub usingnamespace getty.Deserializer(
+            *Self,
+            Error,
+            null,
+            null,
+            .{
+                .deserializeBool = deserializeBool,
+            },
+        );
 
-    pub fn init(s: []const u8) Self {
-        return .{ .tokens = std.json.TokenStream.init(s) };
-    }
+        const Error = getty.de.Error || std.json.Error;
 
-    fn deserializeBool(self: *Self, allocator: ?std.mem.Allocator, v: anytype) Error!@TypeOf(v).Value {
-        if (try self.tokens.next()) |token| {
-            if (token == .True or token == .False) {
-                return try v.visitBool(allocator, De, token == .True);
-            }
+        const De = Self.@"getty.Deserializer";
+
+        pub fn init(allocator: std.mem.Allocator, reader: Reader) Self {
+            return .{
+                .tokens = JsonReader.init(allocator, reader),
+            };
         }
 
-        return error.InvalidType;
-    }
-};
+        pub fn deinit(self: *Self) void {
+            self.tokens.deinit();
+        }
+
+        fn deserializeBool(self: *Self, allocator: ?std.mem.Allocator, v: anytype) Error!@TypeOf(v).Value {
+            const token = try self.tokens.next();
+            if (token == .true or token == .false) {
+                return try v.visitBool(allocator, De, token == .true);
+            }
+
+            return error.InvalidType;
+        }
+    };
+}
 
 pub fn main() anyerror!void {
-    var d = Deserializer.init("true");
+    var fbs = std.io.fixedBufferStream("true");
+    const reader = fbs.reader();
+
+    var d = Deserializer(@TypeOf(reader)).init(std.heap.page_allocator, reader);
+    defer d.deinit();
+
     const v = try getty.deserialize(null, bool, d.deserializer());
 
     std.debug.print("{}, {}\n", .{ v, @TypeOf(v) });

--- a/examples/seq-deserializer/main.zig
+++ b/examples/seq-deserializer/main.zig
@@ -1,85 +1,94 @@
 const std = @import("std");
 const getty = @import("getty");
 
-const Deserializer = struct {
-    tokens: std.json.TokenStream,
+const BUF_SIZE = 1024;
 
-    const Self = @This();
+fn Deserializer(comptime Reader: type) type {
+    const JsonReader = std.json.Reader(BUF_SIZE, Reader);
 
-    pub usingnamespace getty.Deserializer(
-        *Self,
-        Error,
-        null,
-        null,
-        .{
-            .deserializeBool = deserializeBool,
-            .deserializeSeq = deserializeSeq,
-        },
-    );
+    return struct {
+        tokens: JsonReader,
 
-    const Error = getty.de.Error || std.json.TokenStream.Error;
+        const Self = @This();
 
-    const De = Self.@"getty.Deserializer";
-
-    pub fn init(s: []const u8) Self {
-        return .{ .tokens = std.json.TokenStream.init(s) };
-    }
-
-    fn deserializeBool(self: *Self, allocator: ?std.mem.Allocator, v: anytype) Error!@TypeOf(v).Value {
-        if (try self.tokens.next()) |token| {
-            if (token == .True or token == .False) {
-                return try v.visitBool(allocator, De, token == .True);
-            }
-        }
-
-        return error.InvalidType;
-    }
-
-    fn deserializeSeq(self: *Self, allocator: ?std.mem.Allocator, v: anytype) Error!@TypeOf(v).Value {
-        if (try self.tokens.next()) |token| {
-            if (token == .ArrayBegin) {
-                var sa = SeqAccess{ .de = self };
-                return try v.visitSeq(allocator, De, sa.seqAccess());
-            }
-        }
-
-        return error.InvalidType;
-    }
-
-    const SeqAccess = struct {
-        de: *Self,
-
-        pub usingnamespace getty.de.SeqAccess(
-            *@This(),
-            Self.Error,
+        pub usingnamespace getty.Deserializer(
+            *Self,
+            Error,
+            null,
+            null,
             .{
-                .nextElementSeed = nextElementSeed,
+                .deserializeBool = deserializeBool,
+                .deserializeSeq = deserializeSeq,
             },
         );
 
-        fn nextElementSeed(self: *@This(), allocator: ?std.mem.Allocator, seed: anytype) Error!?@TypeOf(seed).Value {
-            const element = seed.deserialize(allocator, self.de.deserializer()) catch |err| {
-                // Encountered end of JSON before ']', so return an error.
-                if (self.de.tokens.i - 1 >= self.de.tokens.slice.len) {
-                    return err;
+        const Error = getty.de.Error || std.json.Error;
+
+        const De = Self.@"getty.Deserializer";
+
+        pub fn init(allocator: std.mem.Allocator, reader: Reader) Self {
+            return .{
+                .tokens = JsonReader.init(allocator, reader),
+            };
+        }
+
+        pub fn deinit(self: *Self) void {
+            self.tokens.deinit();
+        }
+
+        fn deserializeBool(self: *Self, allocator: ?std.mem.Allocator, v: anytype) Error!@TypeOf(v).Value {
+            const token = try self.tokens.next();
+            if (token == .true or token == .false) {
+                return try v.visitBool(allocator, De, token == .true);
+            }
+
+            return error.InvalidType;
+        }
+
+        fn deserializeSeq(self: *Self, allocator: ?std.mem.Allocator, v: anytype) Error!@TypeOf(v).Value {
+            const token = try self.tokens.next();
+            if (token == .array_begin) {
+                var sa = SeqAccess{ .de = self };
+                return try v.visitSeq(allocator, De, sa.seqAccess());
+            }
+
+            return error.InvalidType;
+        }
+
+        const SeqAccess = struct {
+            de: *Self,
+
+            pub usingnamespace getty.de.SeqAccess(
+                *@This(),
+                Self.Error,
+                .{
+                    .nextElementSeed = nextElementSeed,
+                },
+            );
+
+            fn nextElementSeed(self: *@This(), allocator: ?std.mem.Allocator, seed: anytype) Error!?@TypeOf(seed).Value {
+                // If ']' is encountered, return null
+                if (try self.de.tokens.peekNextTokenType() == .array_end) {
+                    return null;
                 }
 
-                // If ']' is encountered, return null. Otherwise, return an error.
-                return switch (self.de.tokens.slice[self.de.tokens.i - 1]) {
-                    ']' => null,
-                    else => err,
-                };
-            };
+                const element = try seed.deserialize(allocator, self.de.deserializer());
 
-            return element;
-        }
+                return element;
+            }
+        };
     };
-};
+}
 
 pub fn main() anyerror!void {
     const allocator = std.heap.page_allocator;
 
-    var d = Deserializer.init("[true, false]");
+    var fbs = std.io.fixedBufferStream("[true, false]");
+    const reader = fbs.reader();
+
+    var d = Deserializer(@TypeOf(reader)).init(allocator, reader);
+    defer d.deinit();
+
     const v = try getty.deserialize(allocator, std.ArrayList(bool), d.deserializer());
     defer v.deinit();
 


### PR DESCRIPTION
1. Update `build.zig` to ensure it can be compiled successfully under Zig 0.11.
2. Update to the latest version of the JSON API.