### PR TITLE
chore: new cast builtin syntax

### DIFF
--- a/src/de/impls/visitor/float.zig
+++ b/src/de/impls/visitor/float.zig
@@ -18,11 +18,11 @@ pub fn Visitor(comptime Float: type) type {
         const Value = Float;
 
         fn visitFloat(_: Self, _: ?std.mem.Allocator, comptime Deserializer: type, input: anytype) Deserializer.Error!Value {
-            return @floatCast(Value, input);
+            return @floatCast(input);
         }
 
         fn visitInt(_: Self, _: ?std.mem.Allocator, comptime Deserializer: type, input: anytype) Deserializer.Error!Value {
-            return @floatFromInt(Value, input);
+            return @floatFromInt(input);
         }
     };
 }

--- a/src/de/impls/visitor/int.zig
+++ b/src/de/impls/visitor/int.zig
@@ -15,7 +15,7 @@ pub fn Visitor(comptime Int: type) type {
         const Value = Int;
 
         fn visitInt(_: Self, _: ?std.mem.Allocator, comptime Deserializer: type, input: anytype) Deserializer.Error!Value {
-            return @intCast(Value, input);
+            return @intCast(input);
         }
     };
 }

--- a/src/de/impls/visitor/slice.zig
+++ b/src/de/impls/visitor/slice.zig
@@ -33,7 +33,7 @@ pub fn Visitor(comptime Slice: type) type {
             }
 
             if (@typeInfo(Value).Pointer.sentinel) |s| {
-                const sentinel_char = @ptrCast(*const Child, s).*;
+                const sentinel_char = @as(*const Child, @ptrCast(s)).*;
                 return try list.toOwnedSliceSentinel(sentinel_char);
             }
 
@@ -55,7 +55,7 @@ pub fn Visitor(comptime Slice: type) type {
             std.mem.copy(u8, output, input);
 
             if (sentinel) |s| {
-                const sentinel_char = @ptrCast(*const u8, s).*;
+                const sentinel_char = @as(*const u8, @ptrCast(s)).*;
                 output[input.len] = sentinel_char;
                 return output[0..input.len :sentinel_char];
             }

--- a/src/de/impls/visitor/struct.zig
+++ b/src/de/impls/visitor/struct.zig
@@ -172,8 +172,7 @@ pub fn Visitor(comptime Struct: type) type {
                     // "default" attribute is not set.
                     if (field.default_value) |default_ptr| {
                         if (!field.is_comptime) {
-                            const aligned_default_ptr = @alignCast(@alignOf(field.type), default_ptr);
-                            const default_value = @ptrCast(*const field.type, aligned_default_ptr).*;
+                            const default_value = @as(*const field.type, @ptrCast(@alignCast(default_ptr))).*;
                             @field(structure, field.name) = default_value;
 
                             break :blk;


### PR DESCRIPTION
Zig 0.11.0-dev.3853 has changed `@***Cast` syntax. The return value type could be inferred now. And the destination type parameter is removed from all cast builtins.


Doc: https://ziglang.org/documentation/master/#alignCast