### PR TITLE
Build: fix after .emit_docs removal from compiler

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -95,9 +95,15 @@ fn docs(b: *std.build.Builder, target: std.zig.CrossTarget, mode: std.builtin.Op
         .target = target,
         .optimize = mode,
     });
-    docs_obj.emit_docs = .emit;
+    docs_obj.emit_bin = .no_emit;
+    const install_docs = b.addInstallDirectory(.{
+        .source_dir = docs_obj.getOutputDocs(),
+        .install_dir = .prefix,
+        .install_subdir = "../docs", //path next to zig-out
+    });
 
     const docs_step = b.step("docs", "Generate project documentation");
     docs_step.dependOn(clean_step);
     docs_step.dependOn(&docs_obj.step);
+    docs_step.dependOn(&install_docs.step);
 }


### PR DESCRIPTION
This commit has removed emit_docs field from lib/std/Build/Step/Compile.zig: https://github.com/ziglang/zig/commit/6e4fff6ba62ae3e61a948c98fa8fea7e35732cc0#diff-ab8b60cc13157d523d61ababea8988046a532f495bad0c3b23ab900a8a4c2745R82

I've just noticed the `docs` branch with https://github.com/getty-zig/getty/commit/0bcc99606723fc0f6ad0218c0b380fa3449a75a0 already fixing this but also changing it. Do you have plans to release that soon on `main`?