### PR TITLE
ser, de: Add support for more standard library types

### DIFF
--- a/src/de/blocks.zig
+++ b/src/de/blocks.zig
@@ -147,6 +147,9 @@ pub const StringHashMapUnmanaged = _HashMap;
 /// Deserialization block for `std.TailQueue`.
 pub const TailQueue = @import("blocks/tail_queue.zig");
 
+/// Deserialization block for `std.SegmentedList`.
+pub const SegmentedList = @import("blocks/segmented_list.zig");
+
 ////////////////////////////////////////////////////////////////////////
 // User-Defined
 ////////////////////////////////////////////////////////////////////////

--- a/src/de/blocks.zig
+++ b/src/de/blocks.zig
@@ -84,6 +84,9 @@ pub const BoundedArray = @import("blocks/bounded_array.zig");
 /// Deserialization block for `std.BufMap` values.
 pub const BufMap = @import("blocks/buf_map.zig");
 
+/// Deserialization block for `std.BufSet` values.
+pub const BufSet = @import("blocks/buf_set.zig");
+
 /// Deserialization block for `std.DynamicBitSet` values.
 pub const DynamicBitSet = _DynamicBitSet;
 

--- a/src/de/blocks.zig
+++ b/src/de/blocks.zig
@@ -108,6 +108,9 @@ pub const MultiArrayList = @import("blocks/multi_array_list.zig");
 /// Deserialization block for `std.net.Address` values.
 pub const NetAddress = @import("blocks/net_address.zig");
 
+/// Deserialization block for `std.Uri`.
+pub const Uri = @import("blocks/uri.zig");
+
 /// Deserialization block for `std.PackedIntArray` values.
 pub const PackedIntArray = _PackedIntEndian;
 

--- a/src/de/blocks/buf_set.zig
+++ b/src/de/blocks/buf_set.zig
@@ -1,0 +1,103 @@
+const std = @import("std");
+
+const BufSetVisitor = @import("../impls/visitor/buf_set.zig").Visitor;
+const getty_free = @import("../free.zig").free;
+const testing = @import("../testing.zig");
+
+const Self = @This();
+
+/// Specifies all types that can be deserialized by this block.
+pub fn is(
+    /// The type being deserialized into.
+    comptime T: type,
+) bool {
+    return T == std.BufSet;
+}
+
+/// Specifies the deserialization process for types relevant to this block.
+pub fn deserialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
+    /// The type being deserialized into.
+    comptime T: type,
+    /// A `getty.Deserializer` interface value.
+    deserializer: anytype,
+    /// A `getty.de.Visitor` interface value.
+    visitor: anytype,
+) !@TypeOf(visitor).Value {
+    _ = T;
+
+    return try deserializer.deserializeSeq(allocator, visitor);
+}
+
+/// Returns a type that implements `getty.de.Visitor`.
+pub fn Visitor(
+    /// The type being deserialized into.
+    comptime T: type,
+) type {
+    return BufSetVisitor(T);
+}
+
+/// Frees resources allocated by Getty during deserialization.
+pub fn free(
+    /// A memory allocator.
+    allocator: std.mem.Allocator,
+    /// A `getty.Deserializer` interface type.
+    comptime Deserializer: type,
+    /// A value to deallocate.
+    value: anytype,
+) void {
+    var it = value.hash_map.keyIterator();
+    while (it.next()) |key_ptr| {
+        getty_free(allocator, Deserializer, key_ptr.*);
+    }
+    var mut = value;
+    mut.hash_map.deinit();
+}
+
+test "deserialize - buf set" {
+    const tests = .{
+        .{
+            .name = "empty",
+            .tokens = &.{
+                .{ .Seq = .{ .len = 0 } },
+                .{ .SeqEnd = {} },
+            },
+            .want = std.BufSet.init(std.testing.allocator),
+        },
+        .{
+            .name = "non-empty",
+            .tokens = &.{
+                .{ .Seq = .{ .len = 3 } },
+                .{ .String = "foo" },
+                .{ .String = "bar" },
+                .{ .String = "baz" },
+                .{ .SeqEnd = {} },
+            },
+            .want = blk: {
+                var want = std.BufSet.init(std.testing.allocator);
+                try want.insert("foo");
+                try want.insert("bar");
+                try want.insert("baz");
+                break :blk want;
+            },
+        },
+    };
+
+    const Deserializer = testing.DefaultDeserializer.@"getty.Deserializer";
+
+    inline for (tests) |t| {
+        defer free(std.testing.allocator, Deserializer, t.want);
+
+        const Want = @TypeOf(t.want);
+        const got = try testing.deserialize(std.testing.allocator, t.name, Self, Want, t.tokens);
+        defer free(std.testing.allocator, Deserializer, got);
+
+        try testing.expectEqual(t.name, t.want.count(), got.count());
+
+        var it = t.want.iterator();
+        while (it.next()) |key_ptr| {
+            try testing.expect(t.name, got.contains(key_ptr.*));
+        }
+    }
+}

--- a/src/de/blocks/segmented_list.zig
+++ b/src/de/blocks/segmented_list.zig
@@ -1,0 +1,104 @@
+const std = @import("std");
+
+const SegmentedListVisitor = @import("../impls/visitor/segmented_list.zig").Visitor;
+const getty_free = @import("../free.zig").free;
+const testing = @import("../testing.zig");
+
+const Self = @This();
+
+/// Specifies all types that can be deserialized by this block.
+pub fn is(
+    /// The type being deserialized into.
+    comptime T: type,
+) bool {
+    return comptime std.mem.startsWith(u8, @typeName(T), "segmented_list.SegmentedList");
+}
+
+/// Specifies the deserialization process for types relevant to this block.
+pub fn deserialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
+    /// The type being deserialized into.
+    comptime T: type,
+    /// A `getty.Deserializer` interface value.
+    deserializer: anytype,
+    /// A `getty.de.Visitor` interface value.
+    visitor: anytype,
+) !@TypeOf(visitor).Value {
+    _ = T;
+
+    return try deserializer.deserializeSeq(allocator, visitor);
+}
+
+/// Returns a type that implements `getty.de.Visitor`.
+pub fn Visitor(
+    /// The type being deserialized into.
+    comptime T: type,
+) type {
+    return SegmentedListVisitor(T);
+}
+
+/// Frees resources allocated by Getty during deserialization.
+pub fn free(
+    /// A memory allocator.
+    allocator: std.mem.Allocator,
+    /// A `getty.Deserializer` interface type.
+    comptime Deserializer: type,
+    /// A value to deallocate.
+    value: anytype,
+) void {
+    var it = value.constIterator(0);
+    while (it.next()) |elem| {
+        getty_free(allocator, Deserializer, elem.*);
+    }
+    var mut = value;
+    mut.deinit(allocator);
+}
+
+test "deserialize - segmented list" {
+    const tests = .{
+        .{
+            .name = "empty",
+            .tokens = &.{
+                .{ .Seq = .{ .len = 0 } },
+                .{ .SeqEnd = {} },
+            },
+            .want = std.SegmentedList(u32, 0){},
+        },
+        .{
+            .name = "non-empty",
+            .tokens = &.{
+                .{ .Seq = .{ .len = 4 } },
+                .{ .U32 = 4 },
+                .{ .U32 = 2 },
+                .{ .U32 = 1 },
+                .{ .U32 = 8 },
+                .{ .SeqEnd = {} },
+            },
+            .want = blk: {
+                var list = std.SegmentedList(u32, 0){};
+                try list.append(std.testing.allocator, 4);
+                try list.append(std.testing.allocator, 2);
+                try list.append(std.testing.allocator, 1);
+                try list.append(std.testing.allocator, 8);
+                break :blk list;
+            },
+        },
+    };
+
+    const Deserializer = testing.DefaultDeserializer.@"getty.Deserializer";
+
+    inline for (tests) |t| {
+        defer free(std.testing.allocator, Deserializer, t.want);
+
+        const Want = @TypeOf(t.want);
+        const got = try testing.deserialize(std.testing.allocator, t.name, Self, Want, t.tokens);
+        defer free(std.testing.allocator, Deserializer, got);
+
+        try testing.expectEqual(t.name, t.want.len, got.len);
+
+        for (0..t.want.len) |i| {
+            try testing.expectEqual(t.name, t.want.at(i).*, got.at(i).*);
+        }
+    }
+}

--- a/src/de/blocks/semantic_version.zig
+++ b/src/de/blocks/semantic_version.zig
@@ -121,11 +121,10 @@ test "deserialize - std.SemanticVersion" {
                 testing.deserializeErr(std.testing.allocator, Self, std.SemanticVersion, t.tokens),
             );
         } else {
+            const Deserializer = testing.DefaultDeserializer.@"getty.Deserializer";
+
             const got = try testing.deserialize(std.testing.allocator, t.name, Self, @TypeOf(t.want), t.tokens);
-            defer {
-                if (got.pre) |pre| std.testing.allocator.free(pre);
-                if (got.build) |build| std.testing.allocator.free(build);
-            }
+            defer free(std.testing.allocator, Deserializer, got);
 
             try testing.expectEqual(t.name, t.want.major, got.major);
             try testing.expectEqual(t.name, t.want.minor, got.minor);

--- a/src/de/blocks/uri.zig
+++ b/src/de/blocks/uri.zig
@@ -1,0 +1,133 @@
+const std = @import("std");
+
+const UriVisitor = @import("../impls/visitor/uri.zig");
+const testing = @import("../testing.zig");
+
+const Self = @This();
+
+/// Specifies all types that can be deserialized by this block.
+pub fn is(
+    /// The type being deserialized into.
+    comptime T: type,
+) bool {
+    return T == std.Uri;
+}
+
+/// Specifies the deserialization process for types relevant to this block.
+pub fn deserialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
+    /// The type being deserialized into.
+    comptime T: type,
+    /// A `getty.Deserializer` interface value.
+    deserializer: anytype,
+    /// A `getty.de.Visitor` interface value.
+    visitor: anytype,
+) !@TypeOf(visitor).Value {
+    _ = T;
+
+    return try deserializer.deserializeString(allocator, visitor);
+}
+
+/// Returns a type that implements `getty.de.Visitor`.
+pub fn Visitor(
+    /// The type being deserialized into.
+    comptime T: type,
+) type {
+    _ = T;
+
+    return UriVisitor;
+}
+
+/// Frees resources allocated by Getty during deserialization.
+pub fn free(
+    /// A memory allocator.
+    allocator: std.mem.Allocator,
+    /// A `getty.Deserializer` interface type.
+    comptime _: type,
+    /// A value to deallocate.
+    value: anytype,
+) void {
+    allocator.free(value.scheme);
+    allocator.free(value.path);
+    if (value.host) |host| allocator.free(host);
+    if (value.user) |user| allocator.free(user);
+    if (value.password) |password| allocator.free(password);
+    if (value.query) |query| allocator.free(query);
+    if (value.fragment) |fragment| allocator.free(fragment);
+}
+
+test "deserialize - std.Uri" {
+    const tests = .{
+        .{
+            .name = "rfc example 1",
+            .tokens = &.{.{ .String = "foo://example.com:8042/over/there?name=ferret#nose" }},
+            .want = std.Uri{
+                .scheme = "foo",
+                .user = null,
+                .password = null,
+                .host = "example.com",
+                .port = 8042,
+                .path = "/over/there",
+                .query = "name=ferret",
+                .fragment = "nose",
+            },
+        },
+        .{
+            .name = "rfc example 2",
+            .tokens = &.{.{ .String = "urn:example:animal:ferret:nose" }},
+            .want = std.Uri{
+                .scheme = "urn",
+                .user = null,
+                .password = null,
+                .host = null,
+                .port = null,
+                .path = "example:animal:ferret:nose",
+                .query = null,
+                .fragment = null,
+            },
+        },
+    };
+
+    inline for (tests) |t| {
+        const Test = @TypeOf(t);
+
+        if (@hasField(Test, "want_err")) {
+            try testing.expectError(
+                t.name,
+                t.want_err,
+                testing.deserializeErr(std.testing.allocator, Self, std.SemanticVersion, t.tokens),
+            );
+        } else {
+            const Deserializer = testing.DefaultDeserializer.@"getty.Deserializer";
+
+            const got = try testing.deserialize(std.testing.allocator, t.name, Self, @TypeOf(t.want), t.tokens);
+            defer free(std.testing.allocator, Deserializer, got);
+
+            try testing.expectEqualStrings(t.name, t.want.scheme, got.scheme);
+            try testing.expectEqual(t.name, t.want.port, got.port);
+            try testing.expectEqualStrings(t.name, t.want.path, got.path);
+
+            if (t.want.host) |host| {
+                try testing.expect(t.name, got.host != null);
+                try testing.expectEqualStrings(t.name, host, got.host.?);
+            }
+            if (t.want.user) |user| {
+                try testing.expect(t.name, got.user != null);
+                try testing.expectEqualStrings(t.name, user, got.user.?);
+            }
+            if (t.want.password) |password| {
+                try testing.expect(t.name, got.password != null);
+                try testing.expectEqualStrings(t.name, password, got.password.?);
+            }
+            if (t.want.query) |query| {
+                try testing.expect(t.name, got.query != null);
+                try testing.expectEqualStrings(t.name, query, got.query.?);
+            }
+            if (t.want.fragment) |fragment| {
+                try testing.expect(t.name, got.fragment != null);
+                try testing.expectEqualStrings(t.name, fragment, got.fragment.?);
+            }
+        }
+    }
+}

--- a/src/de/impls/visitor/buf_set.zig
+++ b/src/de/impls/visitor/buf_set.zig
@@ -1,0 +1,37 @@
+const std = @import("std");
+
+const free = @import("../../free.zig").free;
+const VisitorInterface = @import("../../interfaces/visitor.zig").Visitor;
+
+pub fn Visitor(comptime BufSet: type) type {
+    return struct {
+        const Self = @This();
+
+        pub usingnamespace VisitorInterface(
+            Self,
+            Value,
+            .{ .visitSeq = visitSeq },
+        );
+
+        const Value = BufSet;
+
+        fn visitSeq(_: Self, allocator: ?std.mem.Allocator, comptime Deserializer: type, seq: anytype) Deserializer.Error!Value {
+            if (allocator == null) {
+                return error.MissingAllocator;
+            }
+
+            const a = allocator.?;
+
+            var set = BufSet.init(a);
+            errdefer free(a, Deserializer, set);
+
+            while (try seq.nextElement(a, []const u8)) |elem| {
+                defer free(a, Deserializer, elem);
+
+                try set.insert(elem);
+            }
+
+            return set;
+        }
+    };
+}

--- a/src/de/impls/visitor/segmented_list.zig
+++ b/src/de/impls/visitor/segmented_list.zig
@@ -1,0 +1,31 @@
+const std = @import("std");
+
+const free = @import("../../free.zig").free;
+const VisitorInterface = @import("../../interfaces/visitor.zig").Visitor;
+
+pub fn Visitor(comptime SegmentedList: type) type {
+    return struct {
+        const Self = @This();
+
+        pub usingnamespace VisitorInterface(
+            Self,
+            Value,
+            .{ .visitSeq = visitSeq },
+        );
+
+        const Value = SegmentedList;
+
+        fn visitSeq(_: Self, allocator: ?std.mem.Allocator, comptime Deserializer: type, seq: anytype) Deserializer.Error!Value {
+            var list = SegmentedList{};
+            errdefer free(allocator.?, Deserializer, list);
+
+            const E = std.meta.Child(std.meta.FieldType(SegmentedList, .prealloc_segment));
+
+            while (try seq.nextElement(allocator, E)) |elem| {
+                try list.append(allocator.?, elem);
+            }
+
+            return list;
+        }
+    };
+}

--- a/src/de/impls/visitor/semantic_version.zig
+++ b/src/de/impls/visitor/semantic_version.zig
@@ -20,21 +20,20 @@ fn visitString(_: Visitor, allocator: ?std.mem.Allocator, comptime Deserializer:
         return error.MissingAllocator;
     }
 
+    const a = allocator.?;
+
     var ver = std.SemanticVersion.parse(input) catch return error.InvalidValue;
-    errdefer {
-        if (ver.pre) |pre| allocator.?.free(pre);
-        if (ver.build) |build| allocator.?.free(build);
-    }
+    errdefer free(a, Deserializer, ver);
 
     if (ver.pre == null and ver.build == null) {
         return ver;
     }
 
     if (ver.pre) |pre| {
-        ver.pre = try allocator.?.dupe(u8, pre);
+        ver.pre = try a.dupe(u8, pre);
     }
     if (ver.build) |build| {
-        ver.build = try allocator.?.dupe(u8, build);
+        ver.build = try a.dupe(u8, build);
     }
 
     return ver;

--- a/src/de/impls/visitor/uri.zig
+++ b/src/de/impls/visitor/uri.zig
@@ -1,0 +1,48 @@
+const std = @import("std");
+
+const free = @import("../../free.zig").free;
+const VisitorInterface = @import("../../interfaces/visitor.zig").Visitor;
+
+const Visitor = @This();
+
+pub usingnamespace VisitorInterface(
+    Visitor,
+    Value,
+    .{
+        .visitString = visitString,
+    },
+);
+
+const Value = std.Uri;
+
+fn visitString(_: Visitor, allocator: ?std.mem.Allocator, comptime Deserializer: type, input: anytype) Deserializer.Error!Value {
+    if (allocator == null) {
+        return error.MissingAllocator;
+    }
+
+    const a = allocator.?;
+
+    var uri = std.Uri.parse(input) catch return error.InvalidValue;
+    errdefer free(a, Deserializer, uri);
+
+    uri.scheme = try a.dupe(u8, uri.scheme);
+    uri.path = try a.dupe(u8, uri.path);
+
+    if (uri.host) |host| {
+        uri.host = try a.dupe(u8, host);
+    }
+    if (uri.user) |user| {
+        uri.user = try a.dupe(u8, user);
+    }
+    if (uri.password) |password| {
+        uri.password = try a.dupe(u8, password);
+    }
+    if (uri.query) |query| {
+        uri.query = try a.dupe(u8, query);
+    }
+    if (uri.fragment) |fragment| {
+        uri.fragment = try a.dupe(u8, fragment);
+    }
+
+    return uri;
+}

--- a/src/de/tuples.zig
+++ b/src/de/tuples.zig
@@ -57,6 +57,7 @@ pub const dt = .{
     blocks.IntegerBitSet,
     //blocks.MultiArrayList,
     //blocks.NetAddress,
+    blocks.Uri,
 
     // Covers the following types:
     //

--- a/src/de/tuples.zig
+++ b/src/de/tuples.zig
@@ -70,6 +70,7 @@ pub const dt = .{
     blocks.SemanticVersion,
     blocks.SinglyLinkedList,
     blocks.TailQueue,
+    blocks.SegmentedList,
 
     ////////////////////////////////////////////////////////////////////////////
     // User-Defined

--- a/src/de/tuples.zig
+++ b/src/de/tuples.zig
@@ -34,6 +34,7 @@ pub const dt = .{
 
     blocks.BoundedArray,
     blocks.BufMap,
+    blocks.BufSet,
     blocks.DynamicBitSet,
     blocks.DynamicBitSetUnmanaged,
 

--- a/src/ser/blocks.zig
+++ b/src/ser/blocks.zig
@@ -114,6 +114,9 @@ pub const MultiArrayList = @import("blocks/multi_array_list.zig");
 /// Serialization block for `std.net.Address` values.
 pub const NetAddress = @import("blocks/net_address.zig");
 
+/// Serialization block for `std.Uri` values.
+pub const Uri = @import("blocks/uri.zig");
+
 /// Serialization block for `std.PackedIntArray` values.
 pub const PackedIntArray = _PackedIntEndian;
 

--- a/src/ser/blocks.zig
+++ b/src/ser/blocks.zig
@@ -153,6 +153,9 @@ pub const StringHashMapUnmanaged = _HashMap;
 /// Serialization block for `std.TailQueue`.
 pub const TailQueue = @import("blocks/tail_queue.zig");
 
+/// Serialization block for `std.SegmentedList`.
+pub const SegmentedList = @import("blocks/segmented_list.zig");
+
 ////////////////////////////////////////////////////////////////////////////
 // Aggregates
 //

--- a/src/ser/blocks.zig
+++ b/src/ser/blocks.zig
@@ -90,6 +90,9 @@ pub const BoundedArray = @import("blocks/bounded_array.zig");
 /// Serialization block for `std.BufMap` values.
 pub const BufMap = @import("blocks/buf_map.zig");
 
+/// Serialization block for `std.BufSet` values.
+pub const BufSet = @import("blocks/buf_set.zig");
+
 /// Serialization block for `std.DynamicBitSet` values.
 pub const DynamicBitSet = @import("blocks/dynamic_bit_set.zig");
 

--- a/src/ser/blocks/buf_set.zig
+++ b/src/ser/blocks/buf_set.zig
@@ -1,0 +1,50 @@
+const std = @import("std");
+
+const getty_serialize = @import("../serialize.zig").serialize;
+const t = @import("../testing.zig");
+
+/// Specifies all types that can be serialized by this block.
+pub fn is(
+    /// The type of a value being serialized.
+    comptime T: type,
+) bool {
+    return T == std.BufSet;
+}
+
+/// Specifies the serialization process for values relevant to this block.
+pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
+    /// A value being serialized.
+    value: anytype,
+    /// A `getty.Serializer` interface value.
+    serializer: anytype,
+) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+    _ = allocator;
+
+    var s = try serializer.serializeSeq(value.count());
+    const seq = s.seq();
+    var it = value.iterator();
+    while (it.next()) |key_ptr| {
+        try seq.serializeElement(key_ptr.*);
+    }
+    return try seq.end();
+}
+
+test "serialize - buf set" {
+    var set = std.BufSet.init(std.testing.allocator);
+    defer set.deinit();
+
+    try t.run(null, serialize, set, &.{
+        .{ .Seq = .{ .len = 0 } },
+        .{ .SeqEnd = {} },
+    });
+
+    try set.insert("foobar");
+
+    try t.run(null, serialize, set, &.{
+        .{ .Seq = .{ .len = 1 } },
+        .{ .String = "foobar" },
+        .{ .SeqEnd = {} },
+    });
+}

--- a/src/ser/blocks/segmented_list.zig
+++ b/src/ser/blocks/segmented_list.zig
@@ -1,0 +1,54 @@
+const std = @import("std");
+
+const t = @import("../testing.zig");
+
+/// Specifies all types that can be serialized by this block.
+pub fn is(
+    /// The type of a value being serialized.
+    comptime T: type,
+) bool {
+    return comptime std.mem.startsWith(u8, @typeName(T), "segmented_list.SegmentedList");
+}
+
+/// Specifies the serialization process for values relevant to this block.
+pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
+    /// A value being serialized.
+    value: anytype,
+    /// A `getty.Serializer` interface value.
+    serializer: anytype,
+) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+    _ = allocator;
+
+    var s = try serializer.serializeSeq(value.len);
+    const seq = s.seq();
+    var it = value.constIterator(0);
+    while (it.next()) |elem| {
+        try seq.serializeElement(elem.*);
+    }
+    return try seq.end();
+}
+
+test "serialize - segmented list" {
+    var list = std.SegmentedList(u32, 0){};
+    defer list.deinit(std.testing.allocator);
+
+    try t.run(null, serialize, list, &.{
+        .{ .Seq = .{ .len = 0 } },
+        .{ .SeqEnd = {} },
+    });
+
+    try list.appendSlice(std.testing.allocator, &[_]u32{ 1, 2, 4, 8, 16, 32 });
+
+    try t.run(null, serialize, list, &.{
+        .{ .Seq = .{ .len = 6 } },
+        .{ .U32 = 1 },
+        .{ .U32 = 2 },
+        .{ .U32 = 4 },
+        .{ .U32 = 8 },
+        .{ .U32 = 16 },
+        .{ .U32 = 32 },
+        .{ .SeqEnd = {} },
+    });
+}

--- a/src/ser/blocks/uri.zig
+++ b/src/ser/blocks/uri.zig
@@ -1,0 +1,64 @@
+const std = @import("std");
+
+const t = @import("../testing.zig");
+
+/// Specifies all types that can be serialized by this block.
+pub fn is(
+    /// The type of a value being serialized.
+    comptime T: type,
+) bool {
+    return T == std.Uri;
+}
+
+/// Specifies the serialization process for values relevant to this block.
+pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
+    /// A value being serialized.
+    value: anytype,
+    /// A `getty.Serializer` interface value.
+    serializer: anytype,
+) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+    if (allocator) |a| {
+        const str = try std.fmt.allocPrint(a, "{+/#}", .{value});
+        defer a.free(str);
+
+        return try serializer.serializeString(str);
+    }
+
+    return error.MissingAllocator;
+}
+
+test "serialize - std.Uri" {
+    // RFC example 1
+    {
+        const uri = std.Uri{
+            .scheme = "foo",
+            .user = null,
+            .password = null,
+            .host = "example.com",
+            .port = 8042,
+            .path = "/over/there",
+            .query = "name=ferret",
+            .fragment = "nose",
+        };
+
+        t.run(std.testing.allocator, serialize, uri, &.{.{ .String = "foo://example.com:8042/over/there?name=ferret#nose" }}) catch return error.UnexpectedTestError;
+    }
+
+    // RFC example 2
+    {
+        const uri = std.Uri{
+            .scheme = "urn",
+            .user = null,
+            .password = null,
+            .host = null,
+            .port = null,
+            .path = "example:animal:ferret:nose",
+            .query = null,
+            .fragment = null,
+        };
+
+        t.run(std.testing.allocator, serialize, uri, &.{.{ .String = "urn:example:animal:ferret:nose" }}) catch return error.UnexpectedTestError;
+    }
+}

--- a/src/ser/tuples.zig
+++ b/src/ser/tuples.zig
@@ -67,6 +67,7 @@ pub const st = .{
 
     blocks.MultiArrayList,
     blocks.NetAddress,
+    blocks.Uri,
 
     // Covers the following types:
     //

--- a/src/ser/tuples.zig
+++ b/src/ser/tuples.zig
@@ -80,6 +80,7 @@ pub const st = .{
     blocks.SinglyLinkedList,
     blocks.SemanticVersion,
     blocks.TailQueue,
+    blocks.SegmentedList,
 
     ////////////////////////////////////////////////////////////////////////////
     // Aggregates

--- a/src/ser/tuples.zig
+++ b/src/ser/tuples.zig
@@ -45,6 +45,7 @@ pub const st = .{
 
     blocks.BoundedArray,
     blocks.BufMap,
+    blocks.BufSet,
     blocks.DynamicBitSet,
     blocks.DynamicBitSetUnmanaged,
 


### PR DESCRIPTION
Context: https://github.com/getty-zig/getty/issues/120

Added (de)serialization support for the following standard library types:
- BufSet
- Uri
- SegementedList
