### PR TITLE
chore: update build.zig to new std.Build API

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -57,16 +57,16 @@ fn tests(b: *std.build.Builder, target: std.zig.CrossTarget, mode: std.builtin.O
         .root_source_file = .{ .path = "src/ser/ser.zig" },
         .target = target,
         .optimize = mode,
+        .main_pkg_path = .{ .path = "src/" },
     });
-    t_ser.setMainPkgPath("src/");
 
     const t_de = b.addTest(.{
         .name = "deserialization test",
         .root_source_file = .{ .path = "src/de/de.zig" },
         .target = target,
         .optimize = mode,
+        .main_pkg_path = .{ .path = "src/" },
     });
-    t_de.setMainPkgPath("src/");
 
     // Configure module-level test steps.
     test_ser_step.dependOn(&b.addRunArtifact(t_ser).step);
@@ -86,7 +86,6 @@ fn docs(b: *std.build.Builder, target: std.zig.CrossTarget, mode: std.builtin.Op
         .target = target,
         .optimize = mode,
     });
-    doc_obj.emit_bin = .no_emit;
 
     const install_docs = b.addInstallDirectory(.{
         .source_dir = doc_obj.getEmittedDocs(),


### PR DESCRIPTION
- `Compile.emit_X` fields has been replaced by `Compile.getEmittedX()` functions in https://github.com/ziglang/zig/commit/5c0181841081170a118d8e50af2a09f5006f59e1, artifacts now default to not being emitted
- `Compile.setMainPkgPath` has been removed with `main_pkg_path` now being an option as part of https://github.com/ziglang/zig/commit/38840e2e586d71f2b38ed825ea02529f615c5f0c