### PR TITLE
ser, de: Add support for more standard library types #2

### DIFF
--- a/src/de/blocks.zig
+++ b/src/de/blocks.zig
@@ -111,6 +111,12 @@ pub const EnumMap = _IndexedMap;
 /// Deserialization block for `std.IndexedMap` values.
 pub const IndexedMap = _IndexedMap;
 
+/// Deserialization block for `std.EnumMultiset` values.
+pub const EnumMultiset = _EnumMultiset;
+
+/// Deserialization block for `std.BoundedEnumMultiset` values.
+pub const BoundedEnumMultiset = _EnumMultiset;
+
 /// Deserialization block for `std.HashMap` values.
 pub const HashMap = _HashMap;
 
@@ -193,3 +199,4 @@ const _StaticBitSet = @import("blocks/static_bit_set.zig");
 const _IndexedArray = @import("blocks/indexed_array.zig");
 const _IndexedSet = @import("blocks/indexed_set.zig");
 const _IndexedMap = @import("blocks/indexed_map.zig");
+const _EnumMultiset = @import("blocks/enum_multiset.zig");

--- a/src/de/blocks.zig
+++ b/src/de/blocks.zig
@@ -93,6 +93,18 @@ pub const DynamicBitSet = _DynamicBitSet;
 /// Deserialization block for `std.DynamicBitSetUnmanaged` values.
 pub const DynamicBitSetUnmanaged = _DynamicBitSet;
 
+/// Deserialization block for `std.EnumArray` values.
+pub const EnumArray = _IndexedArray;
+
+/// Deserialization block for `std.IndexedArray` values.
+pub const IndexedArray = _IndexedArray;
+
+/// Deserialization block for `std.BoundedEnumMultiset` values.
+pub const BoundedEnumMultiset = _EnumMultiset;
+
+/// Deserialization block for `std.EnumMultiset` values.
+pub const EnumMultiset = _EnumMultiset;
+
 /// Deserialization block for `std.HashMap` values.
 pub const HashMap = _HashMap;
 
@@ -172,3 +184,5 @@ const _DynamicBitSet = @import("blocks/dynamic_bit_set.zig");
 const _HashMap = @import("blocks/hash_map.zig");
 const _PackedIntEndian = @import("blocks/packed_int_endian.zig");
 const _StaticBitSet = @import("blocks/static_bit_set.zig");
+const _IndexedArray = @import("blocks/indexed_array.zig");
+const _EnumMultiset = @import("blocks/enum_multiset.zig");

--- a/src/de/blocks.zig
+++ b/src/de/blocks.zig
@@ -129,6 +129,9 @@ pub const SemanticVersion = @import("blocks/semantic_version.zig");
 /// Deserialization block for `std.PriorityQueue` values.
 pub const PriorityQueue = @import("blocks/priority_queue.zig");
 
+/// Deserialization block for `std.PriorityDequeue` values.
+pub const PriorityDequeue = @import("blocks/priority_dequeue.zig");
+
 /// Deserialization block for `std.SinglyLinkedList` values.
 pub const SinglyLinkedList = @import("blocks/singly_linked_list.zig");
 

--- a/src/de/blocks.zig
+++ b/src/de/blocks.zig
@@ -99,11 +99,11 @@ pub const EnumArray = _IndexedArray;
 /// Deserialization block for `std.IndexedArray` values.
 pub const IndexedArray = _IndexedArray;
 
-/// Deserialization block for `std.BoundedEnumMultiset` values.
-pub const BoundedEnumMultiset = _EnumMultiset;
+/// Deserialization block for `std.Enummap` values.
+pub const EnumMap = _IndexedMap;
 
-/// Deserialization block for `std.EnumMultiset` values.
-pub const EnumMultiset = _EnumMultiset;
+/// Deserialization block for `std.IndexedMap` values.
+pub const IndexedMap = _IndexedMap;
 
 /// Deserialization block for `std.HashMap` values.
 pub const HashMap = _HashMap;
@@ -185,4 +185,4 @@ const _HashMap = @import("blocks/hash_map.zig");
 const _PackedIntEndian = @import("blocks/packed_int_endian.zig");
 const _StaticBitSet = @import("blocks/static_bit_set.zig");
 const _IndexedArray = @import("blocks/indexed_array.zig");
-const _EnumMultiset = @import("blocks/enum_multiset.zig");
+const _IndexedMap = @import("blocks/indexed_map.zig");

--- a/src/de/blocks.zig
+++ b/src/de/blocks.zig
@@ -177,6 +177,9 @@ pub const StringHashMapUnmanaged = _HashMap;
 /// Deserialization block for `std.TailQueue`.
 pub const TailQueue = @import("blocks/tail_queue.zig");
 
+/// Deserialization block for `std.LinearFifo`.
+pub const LinearFifo = @import("blocks/linear_fifo.zig");
+
 /// Deserialization block for `std.SegmentedList`.
 pub const SegmentedList = @import("blocks/segmented_list.zig");
 

--- a/src/de/blocks.zig
+++ b/src/de/blocks.zig
@@ -99,6 +99,12 @@ pub const EnumArray = _IndexedArray;
 /// Deserialization block for `std.IndexedArray` values.
 pub const IndexedArray = _IndexedArray;
 
+/// Deserialization block for `std.EnumSet` values.
+pub const EnumSet = _IndexedSet;
+
+/// Deserialization block for `std.IndexedSet` values.
+pub const IndexedSet = _IndexedSet;
+
 /// Deserialization block for `std.Enummap` values.
 pub const EnumMap = _IndexedMap;
 
@@ -185,4 +191,5 @@ const _HashMap = @import("blocks/hash_map.zig");
 const _PackedIntEndian = @import("blocks/packed_int_endian.zig");
 const _StaticBitSet = @import("blocks/static_bit_set.zig");
 const _IndexedArray = @import("blocks/indexed_array.zig");
+const _IndexedSet = @import("blocks/indexed_set.zig");
 const _IndexedMap = @import("blocks/indexed_map.zig");

--- a/src/de/blocks.zig
+++ b/src/de/blocks.zig
@@ -126,6 +126,9 @@ pub const PackedIntSliceEndian = _PackedIntEndian;
 /// Deserialization block for `std.SemanticVersion`.
 pub const SemanticVersion = @import("blocks/semantic_version.zig");
 
+/// Deserialization block for `std.PriorityQueue` values.
+pub const PriorityQueue = @import("blocks/priority_queue.zig");
+
 /// Deserialization block for `std.SinglyLinkedList` values.
 pub const SinglyLinkedList = @import("blocks/singly_linked_list.zig");
 

--- a/src/de/blocks/enum_multiset.zig
+++ b/src/de/blocks/enum_multiset.zig
@@ -1,0 +1,183 @@
+const std = @import("std");
+
+const EnumMultisetVisitor = @import("../impls/visitor/enum_multiset.zig").Visitor;
+const getty_free = @import("../free.zig").free;
+const testing = @import("../testing.zig");
+
+const Self = @This();
+
+/// Specifies all types that can be deserialized by this block.
+pub fn is(
+    /// The type being deserialized into.
+    comptime T: type,
+) bool {
+    const is_bounded_enum_multiset = comptime std.mem.startsWith(u8, @typeName(T), "enums.BoundedEnumMultiset");
+    const is_enum_multiset = comptime std.mem.startsWith(u8, @typeName(T), "enums.EnumMultiset");
+
+    return is_bounded_enum_multiset or is_enum_multiset;
+}
+
+/// Specifies the deserialization process for types relevant to this block.
+pub fn deserialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
+    /// The type being deserialized into.
+    comptime T: type,
+    /// A `getty.Deserializer` interface value.
+    deserializer: anytype,
+    /// A `getty.de.Visitor` interface value.
+    visitor: anytype,
+) !@TypeOf(visitor).Value {
+    _ = T;
+
+    return try deserializer.deserializeSeq(allocator, visitor);
+}
+
+/// Returns a type that implements `getty.de.Visitor`.
+pub fn Visitor(
+    /// The type being deserialized into.
+    comptime T: type,
+) type {
+    return EnumMultisetVisitor(T);
+}
+
+/// Frees resources allocated by Getty during deserialization.
+pub fn free(
+    /// A memory allocator.
+    allocator: std.mem.Allocator,
+    /// A `getty.Deserializer` interface type.
+    comptime Deserializer: type,
+    /// A value to deallocate.
+    value: anytype,
+) void {
+    var mut = value;
+    var it = mut.iterator();
+    while (it.next()) |entry| {
+        getty_free(allocator, Deserializer, entry.value.*);
+    }
+}
+
+const Color = enum { red, blue, yellow };
+
+test "deserialize - std.BoundedEnumMultiset" {
+    const tests = .{
+        .{
+            .name = "zero count",
+            .tokens = &.{
+                .{ .Seq = .{ .len = 0 } },
+                .{ .SeqEnd = {} },
+            },
+            .want = std.enums.BoundedEnumMultiset(Color, u8).initEmpty(),
+        },
+        .{
+            .name = "full count",
+            .tokens = &.{
+                .{ .Seq = .{ .len = 9 } },
+                .{ .String = "red" },
+                .{ .String = "blue" },
+                .{ .String = "yellow" },
+                .{ .String = "red" },
+                .{ .String = "blue" },
+                .{ .String = "yellow" },
+                .{ .String = "red" },
+                .{ .String = "blue" },
+                .{ .String = "yellow" },
+                .{ .SeqEnd = {} },
+            },
+            .want = std.enums.BoundedEnumMultiset(Color, u2).initWithCount(3),
+        },
+        .{
+            .name = "mixed count",
+            .tokens = &.{
+                .{ .Seq = .{ .len = 7 } },
+                .{ .U8 = 0 },
+                .{ .U8 = 0 },
+                .{ .U8 = 1 },
+                .{ .U8 = 1 },
+                .{ .U8 = 1 },
+                .{ .U8 = 1 },
+                .{ .U8 = 2 },
+                .{ .SeqEnd = {} },
+            },
+            .want = blk: {
+                var want = std.enums.BoundedEnumMultiset(Color, u4).initEmpty();
+                want.addAssertSafe(.red, 2);
+                want.addAssertSafe(.blue, 4);
+                want.addAssertSafe(.yellow, 1);
+                break :blk want;
+            },
+        },
+    };
+
+    inline for (tests) |t| {
+        const Want = @TypeOf(t.want);
+        const got = try testing.deserialize(null, t.name, Self, Want, t.tokens);
+
+        try testing.expectEqual(t.name, t.want.count(), got.count());
+        try testing.expect(t.name, t.want.eql(got));
+    }
+}
+
+test "deserialize - std.EnumMultiSet" {
+    const tests = .{
+        .{
+            .name = "zero count",
+            .tokens = &.{
+                .{ .Seq = .{ .len = 0 } },
+                .{ .SeqEnd = {} },
+            },
+            .want = std.enums.EnumMultiset(Color).initEmpty(),
+        },
+        .{
+            .name = "uniform count",
+            .tokens = &.{
+                .{ .Seq = .{ .len = 12 } },
+                .{ .String = "red" },
+                .{ .String = "blue" },
+                .{ .String = "yellow" },
+                .{ .String = "red" },
+                .{ .String = "blue" },
+                .{ .String = "yellow" },
+                .{ .String = "red" },
+                .{ .String = "blue" },
+                .{ .String = "yellow" },
+                .{ .String = "red" },
+                .{ .String = "blue" },
+                .{ .String = "yellow" },
+                .{ .SeqEnd = {} },
+            },
+            .want = std.enums.EnumMultiset(Color).initWithCount(4),
+        },
+        .{
+            .name = "mixed count",
+            .tokens = &.{
+                .{ .Seq = .{ .len = 9 } },
+                .{ .U8 = 0 },
+                .{ .U8 = 0 },
+                .{ .U8 = 1 },
+                .{ .U8 = 1 },
+                .{ .U8 = 1 },
+                .{ .U8 = 1 },
+                .{ .U8 = 0 },
+                .{ .U8 = 2 },
+                .{ .U8 = 2 },
+                .{ .SeqEnd = {} },
+            },
+            .want = blk: {
+                var want = std.enums.EnumMultiset(Color).initEmpty();
+                want.addAssertSafe(.red, 3);
+                want.addAssertSafe(.blue, 4);
+                want.addAssertSafe(.yellow, 2);
+                break :blk want;
+            },
+        },
+    };
+
+    inline for (tests) |t| {
+        const Want = @TypeOf(t.want);
+        const got = try testing.deserialize(null, t.name, Self, Want, t.tokens);
+
+        try testing.expectEqual(t.name, t.want.count(), got.count());
+        try testing.expect(t.name, t.want.eql(got));
+    }
+}

--- a/src/de/blocks/indexed_array.zig
+++ b/src/de/blocks/indexed_array.zig
@@ -1,0 +1,257 @@
+const std = @import("std");
+
+const IndexedArrayVisitor = @import("../impls/visitor/indexed_array.zig").Visitor;
+const getty_free = @import("../free.zig").free;
+const testing = @import("../testing.zig");
+
+const Self = @This();
+
+/// Specifies all types that can be deserialized by this block.
+pub fn is(
+    /// The type being deserialized into.
+    comptime T: type,
+) bool {
+    const is_indexed_array = comptime std.mem.startsWith(u8, @typeName(T), "enums.IndexedArray");
+    const is_enum_array = comptime std.mem.startsWith(u8, @typeName(T), "enums.EnumArray");
+
+    return is_indexed_array or is_enum_array;
+}
+
+/// Specifies the deserialization process for types relevant to this block.
+pub fn deserialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
+    /// The type being deserialized into.
+    comptime T: type,
+    /// A `getty.Deserializer` interface value.
+    deserializer: anytype,
+    /// A `getty.de.Visitor` interface value.
+    visitor: anytype,
+) !@TypeOf(visitor).Value {
+    _ = T;
+
+    return try deserializer.deserializeSeq(allocator, visitor);
+}
+
+/// Returns a type that implements `getty.de.Visitor`.
+pub fn Visitor(
+    /// The type being deserialized into.
+    comptime T: type,
+) type {
+    return IndexedArrayVisitor(T);
+}
+
+/// Frees resources allocated by Getty during deserialization.
+pub fn free(
+    /// A memory allocator.
+    allocator: std.mem.Allocator,
+    /// A `getty.Deserializer` interface type.
+    comptime Deserializer: type,
+    /// A value to deallocate.
+    value: anytype,
+) void {
+    getty_free(allocator, Deserializer, value.values);
+}
+
+fn StringIndexer(comptime str_keys: []const []const u8) type {
+    if (str_keys.len == 0) {
+        return struct {
+            pub const Key = []const u8;
+            pub const count: usize = 0;
+            pub fn indexOf(k: Key) usize {
+                _ = k;
+                unreachable;
+            }
+            pub fn keyForIndex(i: usize) Key {
+                _ = i;
+                unreachable;
+            }
+        };
+    }
+
+    return struct {
+        pub const Key = []const u8;
+        pub const count: usize = str_keys.len;
+        pub fn indexOf(k: Key) usize {
+            for (str_keys, 0..) |key, i| {
+                if (std.mem.eql(u8, k, key)) {
+                    return i;
+                }
+            }
+            unreachable;
+        }
+        pub fn keyForIndex(i: usize) Key {
+            return str_keys[i];
+        }
+    };
+}
+
+test "deserialize - std.IndexedArray" {
+    const Color = StringIndexer(&.{ "red", "yellow", "blue" });
+    const Size = StringIndexer(&.{ "small", "medium", "large" });
+
+    const tests = .{
+        .{
+            .name = "empty",
+            .tokens = &.{
+                .{ .Seq = .{ .len = 0 } },
+                .{ .SeqEnd = {} },
+            },
+            .want = std.enums.IndexedArray(StringIndexer(&.{}), u32, null).initUndefined(),
+        },
+        .{
+            .name = "non-empty",
+            .tokens = &.{
+                .{ .Seq = .{ .len = 3 } },
+                .{ .U32 = 1 },
+                .{ .U32 = 3 },
+                .{ .U32 = 2 },
+                .{ .SeqEnd = {} },
+            },
+            .want = blk: {
+                var want = std.enums.IndexedArray(Color, u32, null).initUndefined();
+                want.set("red", 1);
+                want.set("yellow", 3);
+                want.set("blue", 2);
+                break :blk want;
+            },
+        },
+        .{
+            .name = "nested",
+            .tokens = &.{
+                .{ .Seq = .{ .len = 3 } },
+                .{ .Seq = .{ .len = 3 } },
+                .{ .U32 = 2 },
+                .{ .U32 = 2 },
+                .{ .U32 = 3 },
+                .{ .SeqEnd = {} },
+                .{ .Seq = .{ .len = 3 } },
+                .{ .U32 = 0 },
+                .{ .U32 = 0 },
+                .{ .U32 = 0 },
+                .{ .SeqEnd = {} },
+                .{ .Seq = .{ .len = 3 } },
+                .{ .U32 = 0 },
+                .{ .U32 = 1 },
+                .{ .U32 = 3 },
+                .{ .SeqEnd = {} },
+                .{ .SeqEnd = {} },
+            },
+            .want = blk: {
+                const SubArray = std.enums.IndexedArray(Size, u32, null);
+                const sa_1 = res: {
+                    var arr = SubArray.initFill(2);
+                    arr.set("large", 3);
+                    break :res arr;
+                };
+                const sa_2 = SubArray.initFill(0);
+                const sa_3 = res: {
+                    var arr = SubArray.initUndefined();
+                    arr.set("small", 0);
+                    arr.set("medium", 1);
+                    arr.set("large", 3);
+                    break :res arr;
+                };
+                var want = std.enums.IndexedArray(Color, SubArray, null).initUndefined();
+                want.set("red", sa_1);
+                want.set("yellow", sa_2);
+                want.set("blue", sa_3);
+                break :blk want;
+            },
+        },
+    };
+
+    inline for (tests) |t| {
+        const Want = @TypeOf(t.want);
+        const got = try testing.deserialize(null, t.name, Self, Want, t.tokens);
+        for (t.want.values, 0..) |want, i| {
+            try testing.expectEqual(t.name, want, got.values[i]);
+        }
+    }
+}
+
+test "deserialize - std.EnumArray" {
+    const Color = enum { red, yellow, blue };
+    const Size = enum { small, medium, large };
+
+    const tests = .{
+        // std.EnumIndexer, which is used internally by std.EnumArray,
+        // fails to compile on an empty enum due to field access occuring
+        // before checking field length.
+        // .{
+        //     .name = "empty",
+        //     .tokens = &.{
+        //         .{ .Seq = .{ .len = 0 } },
+        //         .{ .SeqEnd = {} },
+        //     },
+        //     .want = std.enums.EnumArray(enum {}, u32).initUndefined(),
+        // },
+        .{
+            .name = "non-empty",
+            .tokens = &.{
+                .{ .Seq = .{ .len = 3 } },
+                .{ .U32 = 1 },
+                .{ .U32 = 3 },
+                .{ .U32 = 2 },
+                .{ .SeqEnd = {} },
+            },
+            .want = std.enums.EnumArray(Color, u32).init(.{
+                .red = 1,
+                .yellow = 3,
+                .blue = 2,
+            }),
+        },
+        .{
+            .name = "nested",
+            .tokens = &.{
+                .{ .Seq = .{ .len = 3 } },
+                .{ .Seq = .{ .len = 3 } },
+                .{ .U32 = 2 },
+                .{ .U32 = 2 },
+                .{ .U32 = 3 },
+                .{ .SeqEnd = {} },
+                .{ .Seq = .{ .len = 3 } },
+                .{ .U32 = 0 },
+                .{ .U32 = 0 },
+                .{ .U32 = 0 },
+                .{ .SeqEnd = {} },
+                .{ .Seq = .{ .len = 3 } },
+                .{ .U32 = 0 },
+                .{ .U32 = 1 },
+                .{ .U32 = 3 },
+                .{ .SeqEnd = {} },
+                .{ .SeqEnd = {} },
+            },
+            .want = blk: {
+                const SubArray = std.enums.EnumArray(Size, u32);
+                const sa_1 = SubArray.init(.{
+                    .small = 2,
+                    .medium = 2,
+                    .large = 3,
+                });
+                const sa_2 = SubArray.initFill(0);
+                const sa_3 = res: {
+                    var arr = SubArray.initUndefined();
+                    arr.set(.small, 0);
+                    arr.set(.medium, 1);
+                    arr.set(.large, 3);
+                    break :res arr;
+                };
+                var want = std.enums.EnumArray(Color, SubArray).init(.{
+                    .red = sa_1,
+                    .yellow = sa_2,
+                    .blue = sa_3,
+                });
+                break :blk want;
+            },
+        },
+    };
+
+    inline for (tests) |t| {
+        const Want = @TypeOf(t.want);
+        const got = try testing.deserialize(null, t.name, Self, Want, t.tokens);
+        for (t.want.values, 0..) |want, i| {
+            try testing.expectEqual(t.name, want, got.values[i]);
+        }
+    }
+}

--- a/src/de/blocks/indexed_map.zig
+++ b/src/de/blocks/indexed_map.zig
@@ -1,0 +1,225 @@
+const std = @import("std");
+
+const IndexedMapVisitor = @import("../impls/visitor/indexed_map.zig").Visitor;
+const getty_free = @import("../free.zig").free;
+const testing = @import("../testing.zig");
+
+const Self = @This();
+
+/// Specifies all types that can be deserialized by this block.
+pub fn is(
+    /// The type being deserialized into.
+    comptime T: type,
+) bool {
+    const is_indexed_map = comptime std.mem.startsWith(u8, @typeName(T), "enums.IndexedMap");
+    const is_enum_map = comptime std.mem.startsWith(u8, @typeName(T), "enums.EnumMap");
+
+    return is_indexed_map or is_enum_map;
+}
+
+/// Specifies the deserialization process for types relevant to this block.
+pub fn deserialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
+    /// The type being deserialized into.
+    comptime T: type,
+    /// A `getty.Deserializer` interface value.
+    deserializer: anytype,
+    /// A `getty.de.Visitor` interface value.
+    visitor: anytype,
+) !@TypeOf(visitor).Value {
+    _ = T;
+
+    return try deserializer.deserializeMap(allocator, visitor);
+}
+
+/// Returns a type that implements `getty.de.Visitor`.
+pub fn Visitor(
+    /// The type being deserialized into.
+    comptime T: type,
+) type {
+    return IndexedMapVisitor(T);
+}
+
+/// Frees resources allocated by Getty during deserialization.
+pub fn free(
+    /// A memory allocator.
+    allocator: std.mem.Allocator,
+    /// A `getty.Deserializer` interface type.
+    comptime Deserializer: type,
+    /// A value to deallocate.
+    value: anytype,
+) void {
+    var mut = value;
+    var it = mut.iterator();
+    while (it.next()) |entry| {
+        getty_free(allocator, Deserializer, entry.value.*);
+    }
+    getty_free(allocator, Deserializer, value.bits);
+}
+
+fn StringIndexer(comptime str_keys: []const []const u8) type {
+    if (str_keys.len == 0) {
+        return struct {
+            pub const Key = []const u8;
+            pub const count: usize = 0;
+            pub fn indexOf(k: Key) usize {
+                _ = k;
+                unreachable;
+            }
+            pub fn keyForIndex(i: usize) Key {
+                _ = i;
+                unreachable;
+            }
+        };
+    }
+
+    return struct {
+        pub const Key = []const u8;
+        pub const count: usize = str_keys.len;
+        pub fn indexOf(k: Key) usize {
+            for (str_keys, 0..) |key, i| {
+                if (std.mem.eql(u8, k, key)) {
+                    return i;
+                }
+            }
+            unreachable;
+        }
+        pub fn keyForIndex(i: usize) Key {
+            return str_keys[i];
+        }
+    };
+}
+
+test "deserialize - std.IndexedMap" {
+    const Color = StringIndexer(&.{ "red", "yellow", "blue" });
+
+    const tests = .{
+        // std.IndexedMap's put function directly accesses its internal
+        // dense array without checking length of the array. Since the
+        // length of the array is determined by the Indexer, this will
+        // fail to compile with "error: indexing into empty array is not
+        // allowed" on an empty index.
+        // .{
+        //     .name = "zero-sized",
+        //     .tokens = &.{
+        //         .{ .Map = .{ .len = 0 } },
+        //         .{ .MapEnd = {} },
+        //     },
+        //     .want = std.enums.IndexedMap(StringIndexer(&.{}), u32, null){},
+        // },
+        .{
+            .name = "empty",
+            .tokens = &.{
+                .{ .Map = .{ .len = 0 } },
+                .{ .MapEnd = {} },
+            },
+            .want = std.enums.IndexedMap(Color, u32, null){},
+        },
+        .{
+            .name = "non-empty",
+            .tokens = &.{
+                .{ .Map = .{ .len = 3 } },
+                .{ .String = "red" },
+                .{ .U32 = 1 },
+                .{ .String = "yellow" },
+                .{ .U32 = 3 },
+                .{ .String = "blue" },
+                .{ .U32 = 2 },
+                .{ .MapEnd = {} },
+            },
+            .want = blk: {
+                var want = std.enums.IndexedMap(Color, u32, null){};
+                want.put("red", 1);
+                want.put("yellow", 3);
+                want.put("blue", 2);
+                break :blk want;
+            },
+        },
+    };
+
+    const Deserializer = testing.DefaultDeserializer.@"getty.Deserializer";
+
+    inline for (tests) |t| {
+        defer free(std.testing.allocator, Deserializer, t.want);
+
+        const Want = @TypeOf(t.want);
+        const got = try testing.deserialize(std.testing.allocator, t.name, Self, Want, t.tokens);
+        defer free(std.testing.allocator, Deserializer, got);
+
+        try testing.expectEqual(t.name, t.want.count(), got.count());
+
+        var mut = t.want;
+        var it = mut.iterator();
+        while (it.next()) |kv| {
+            try testing.expect(t.name, got.contains(kv.key));
+            try testing.expectEqual(t.name, kv.value.*, got.get(kv.key).?);
+        }
+    }
+}
+
+test "deserialize - std.EnumMap" {
+    const Color = enum { red, yellow, blue };
+
+    const tests = .{
+        // std.EnumIndexer, which is used internally by std.EnumMap,
+        // fails to compile on an empty enum due to field access occuring
+        // before checking field length.
+        // .{
+        //     .name = "zero-sized",
+        //     .tokens = &.{
+        //         .{ .Map = .{ .len = 0 } },
+        //         .{ .MapEnd = {} },
+        //     },
+        //     .want = std.enums.EnumMap(enum {}, u32){},
+        // },
+        .{
+            .name = "empty",
+            .tokens = &.{
+                .{ .Map = .{ .len = 0 } },
+                .{ .MapEnd = {} },
+            },
+            .want = std.enums.EnumMap(Color, u32){},
+        },
+        .{
+            .name = "non-empty",
+            .tokens = &.{
+                .{ .Map = .{ .len = 3 } },
+                .{ .Enum = {} },
+                .{ .String = "red" },
+                .{ .U32 = 1 },
+                .{ .Enum = {} },
+                .{ .String = "yellow" },
+                .{ .U32 = 3 },
+                .{ .Enum = {} },
+                .{ .String = "blue" },
+                .{ .U32 = 2 },
+                .{ .MapEnd = {} },
+            },
+            .want = std.enums.EnumMap(Color, u32).init(.{
+                .red = 1,
+                .yellow = 3,
+                .blue = 2,
+            }),
+        },
+    };
+
+    const Deserializer = testing.DefaultDeserializer.@"getty.Deserializer";
+
+    inline for (tests) |t| {
+        defer free(std.testing.allocator, Deserializer, t.want);
+
+        const Want = @TypeOf(t.want);
+        const got = try testing.deserialize(std.testing.allocator, t.name, Self, Want, t.tokens);
+        defer free(std.testing.allocator, Deserializer, got);
+
+        try testing.expectEqual(t.name, t.want.count(), got.count());
+
+        var mut = t.want;
+        var it = mut.iterator();
+        while (it.next()) |kv| {
+            try testing.expect(t.name, got.contains(kv.key));
+            try testing.expectEqual(t.name, kv.value.*, got.get(kv.key).?);
+        }
+    }
+}

--- a/src/de/blocks/indexed_set.zig
+++ b/src/de/blocks/indexed_set.zig
@@ -1,0 +1,235 @@
+const std = @import("std");
+
+const IndexedSetVisitor = @import("../impls/visitor/indexed_set.zig").Visitor;
+const getty_free = @import("../free.zig").free;
+const testing = @import("../testing.zig");
+
+const Self = @This();
+
+/// Specifies all types that can be deserialized by this block.
+pub fn is(
+    /// The type being deserialized into.
+    comptime T: type,
+) bool {
+    const is_indexed_set = comptime std.mem.startsWith(u8, @typeName(T), "enums.IndexedSet");
+    const is_enum_set = comptime std.mem.startsWith(u8, @typeName(T), "enums.EnumSEt");
+
+    return is_indexed_set or is_enum_set;
+}
+
+/// Specifies the deserialization process for types relevant to this block.
+pub fn deserialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
+    /// The type being deserialized into.
+    comptime T: type,
+    /// A `getty.Deserializer` interface value.
+    deserializer: anytype,
+    /// A `getty.de.Visitor` interface value.
+    visitor: anytype,
+) !@TypeOf(visitor).Value {
+    _ = T;
+
+    return try deserializer.deserializeSeq(allocator, visitor);
+}
+
+/// Returns a type that implements `getty.de.Visitor`.
+pub fn Visitor(
+    /// The type being deserialized into.
+    comptime T: type,
+) type {
+    return IndexedSetVisitor(T);
+}
+
+/// Frees resources allocated by Getty during deserialization.
+pub fn free(
+    /// A memory allocator.
+    allocator: std.mem.Allocator,
+    /// A `getty.Deserializer` interface type.
+    comptime Deserializer: type,
+    /// A value to deallocate.
+    value: anytype,
+) void {
+    getty_free(allocator, Deserializer, value.bits);
+}
+
+fn StringIndexer(comptime str_keys: []const []const u8) type {
+    if (str_keys.len == 0) {
+        return struct {
+            pub const Key = []const u8;
+            pub const count: usize = 0;
+            pub fn indexOf(k: Key) usize {
+                _ = k;
+                unreachable;
+            }
+            pub fn keyForIndex(i: usize) Key {
+                _ = i;
+                unreachable;
+            }
+        };
+    }
+
+    return struct {
+        pub const Key = []const u8;
+        pub const count: usize = str_keys.len;
+        pub fn indexOf(k: Key) usize {
+            for (str_keys, 0..) |key, i| {
+                if (std.mem.eql(u8, k, key)) {
+                    return i;
+                }
+            }
+            unreachable;
+        }
+        pub fn keyForIndex(i: usize) Key {
+            return str_keys[i];
+        }
+    };
+}
+
+test "deserialize - std.IndexedSet" {
+    const Color = StringIndexer(&.{ "red", "yellow", "blue", "green", "orange", "violet", "indigo", "magenta" });
+
+    const tests = .{
+        .{
+            .name = "zero-sized",
+            .tokens = &.{
+                .{ .Seq = .{ .len = 0 } },
+                .{ .SeqEnd = {} },
+            },
+            .want = std.enums.IndexedSet(StringIndexer(&.{}), null).initEmpty(),
+        },
+        .{
+            .name = "empty",
+            .tokens = &.{
+                .{ .Seq = .{ .len = 0 } },
+                .{ .SeqEnd = {} },
+            },
+            .want = std.enums.IndexedSet(Color, null).initEmpty(),
+        },
+        .{
+            .name = "full",
+            .tokens = &.{
+                .{ .Seq = .{ .len = 8 } },
+                .{ .String = "red" },
+                .{ .String = "yellow" },
+                .{ .String = "blue" },
+                .{ .String = "green" },
+                .{ .String = "orange" },
+                .{ .String = "violet" },
+                .{ .String = "indigo" },
+                .{ .String = "magenta" },
+                .{ .SeqEnd = {} },
+            },
+            .want = std.enums.IndexedSet(Color, null).initFull(),
+        },
+        .{
+            .name = "mixed",
+            .tokens = &.{
+                .{ .Seq = .{ .len = 4 } },
+                .{ .String = "red" },
+                .{ .String = "yellow" },
+                .{ .String = "blue" },
+                .{ .String = "violet" },
+                .{ .SeqEnd = {} },
+            },
+            .want = std.enums.IndexedSet(Color, null).initMany(&.{ "red", "yellow", "blue", "violet" }),
+        },
+    };
+
+    const Deserializer = testing.DefaultDeserializer.@"getty.Deserializer";
+
+    inline for (tests) |t| {
+        defer free(std.testing.allocator, Deserializer, t.want);
+
+        const Want = @TypeOf(t.want);
+        const got = try testing.deserialize(std.testing.allocator, t.name, Self, Want, t.tokens);
+        defer free(std.testing.allocator, Deserializer, got);
+
+        try testing.expectEqual(t.name, t.want.count(), got.count());
+        try testing.expect(t.name, t.want.eql(got));
+    }
+}
+
+test "deserialize - std.EnumSet" {
+    const Color = enum { red, yellow, blue, green, orange, violet, indigo, magenta };
+
+    const tests = .{
+        // std.EnumIndexer, which is used internally by std.EnumSet,
+        // fails to compile on an empty enum due to field access occuring
+        // before checking field length.
+        // .{
+        //     .name = "zero-sized",
+        //     .tokens = &.{
+        //         .{ .Seq = .{ .len = 0 } },
+        //         .{ .SeqEnd = {} },
+        //     },
+        //     .want = std.enums.EnumSet(enum {}){},
+        // },
+        .{
+            .name = "empty",
+            .tokens = &.{
+                .{ .Seq = .{ .len = 0 } },
+                .{ .SeqEnd = {} },
+            },
+            .want = std.enums.EnumSet(Color).initEmpty(),
+        },
+        .{
+            .name = "full",
+            .tokens = &.{
+                .{ .Seq = .{ .len = 8 } },
+                .{ .Enum = {} },
+                .{ .String = "red" },
+                .{ .Enum = {} },
+                .{ .String = "yellow" },
+                .{ .Enum = {} },
+                .{ .String = "blue" },
+                .{ .Enum = {} },
+                .{ .String = "green" },
+                .{ .Enum = {} },
+                .{ .String = "orange" },
+                .{ .Enum = {} },
+                .{ .String = "violet" },
+                .{ .Enum = {} },
+                .{ .String = "indigo" },
+                .{ .Enum = {} },
+                .{ .String = "magenta" },
+                .{ .SeqEnd = {} },
+            },
+            .want = std.enums.EnumSet(Color).initFull(),
+        },
+        .{
+            .name = "mixed",
+            .tokens = &.{
+                .{ .Seq = .{ .len = 4 } },
+                .{ .Enum = {} },
+                .{ .String = "red" },
+                .{ .Enum = {} },
+                .{ .String = "yellow" },
+                .{ .Enum = {} },
+                .{ .String = "blue" },
+                .{ .Enum = {} },
+                .{ .String = "violet" },
+                .{ .SeqEnd = {} },
+            },
+            .want = std.enums.EnumSet(Color).init(.{
+                .red = true,
+                .yellow = true,
+                .blue = true,
+                .violet = true,
+            }),
+        },
+    };
+
+    const Deserializer = testing.DefaultDeserializer.@"getty.Deserializer";
+
+    inline for (tests) |t| {
+        defer free(std.testing.allocator, Deserializer, t.want);
+
+        const Want = @TypeOf(t.want);
+        const got = try testing.deserialize(std.testing.allocator, t.name, Self, Want, t.tokens);
+        defer free(std.testing.allocator, Deserializer, got);
+
+        try testing.expectEqual(t.name, t.want.count(), got.count());
+        try testing.expect(t.name, t.want.eql(got));
+    }
+}

--- a/src/de/blocks/linear_fifo.zig
+++ b/src/de/blocks/linear_fifo.zig
@@ -1,0 +1,215 @@
+const std = @import("std");
+
+const getty_free = @import("../free.zig").free;
+const LinearFifoVisitor = @import("../impls/visitor/linear_fifo.zig").Visitor;
+const testing = @import("../testing.zig");
+
+const Self = @This();
+
+/// Specifies all types that can be deserialized by this block.
+pub fn is(
+    /// The type being deserialized into.
+    comptime T: type,
+) bool {
+    return comptime std.mem.startsWith(u8, @typeName(T), "fifo.LinearFifo");
+}
+
+/// Specifies the deserialization process for types relevant to this block.
+pub fn deserialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
+    /// The type being deserialized into.
+    comptime T: type,
+    /// A `getty.Deserializer` interface value.
+    deserializer: anytype,
+    /// A `getty.de.Visitor` interface value.
+    visitor: anytype,
+) !@TypeOf(visitor).Value {
+    _ = T;
+
+    return try deserializer.deserializeSeq(allocator, visitor);
+}
+
+/// Returns a type that implements `getty.de.Visitor`.
+pub fn Visitor(
+    /// The type being deserialized into.
+    comptime T: type,
+) type {
+    return LinearFifoVisitor(T);
+}
+
+/// Frees resources allocated by Getty during deserialization.
+pub fn free(
+    /// A memory allocator.
+    allocator: std.mem.Allocator,
+    /// A `getty.Deserializer` interface type.
+    comptime Deserializer: type,
+    /// A value to deallocate.
+    value: anytype,
+) void {
+    const is_buffer_dynamic = comptime std.meta.FieldType(@TypeOf(value), .allocator) != void;
+    const is_buffer_static = comptime @typeInfo(std.meta.FieldType(@TypeOf(value), .buf)) == .Array;
+
+    // Linearize the buffer so we can read it as a contiguous slice.
+    var mut = value;
+    mut.realign();
+    for (mut.readableSlice(0)) |v| {
+        getty_free(allocator, Deserializer, v);
+    }
+    if (is_buffer_dynamic) {
+        value.deinit();
+    } else if (!is_buffer_static) {
+        allocator.free(value.buf);
+    }
+}
+
+test "deserialize - std.LinearFifo (static)" {
+    const tests = .{
+        .{
+            .name = "empty",
+            .tokens = &.{
+                .{ .Seq = .{ .len = 0 } },
+                .{ .SeqEnd = {} },
+            },
+            .want = std.fifo.LinearFifo(u32, .{ .Static = 8 }).init(),
+        },
+        .{
+            .name = "non-empty",
+            .tokens = &.{
+                .{ .Seq = .{ .len = 8 } },
+                .{ .U32 = 1 },
+                .{ .U32 = 2 },
+                .{ .U32 = 3 },
+                .{ .U32 = 4 },
+                .{ .U32 = 5 },
+                .{ .U32 = 6 },
+                .{ .U32 = 7 },
+                .{ .U32 = 8 },
+                .{ .SeqEnd = {} },
+            },
+            .want = blk: {
+                var want = std.fifo.LinearFifo(u32, .{ .Static = 8 }).init();
+                want.writeAssumeCapacity(&[_]u32{ 1, 2, 3, 4, 1, 2, 3, 4 });
+                want.discard(4);
+                want.writeAssumeCapacity(&[_]u32{ 5, 6, 7, 8 });
+                break :blk want;
+            },
+        },
+    };
+
+    inline for (tests) |t| {
+        const Want = @TypeOf(t.want);
+
+        const got = try testing.deserialize(std.testing.allocator, t.name, Self, Want, t.tokens);
+
+        try testing.expectEqual(t.name, t.want.readableLength(), got.readableLength());
+
+        for (0..t.want.readableLength()) |i| {
+            try testing.expectEqual(t.name, t.want.peekItem(i), got.peekItem(i));
+        }
+    }
+}
+
+test "deserialize - std.LinearFifo (slice)" {
+    var buf: [10]u32 = undefined;
+
+    const tests = .{
+        .{
+            .name = "empty",
+            .tokens = &.{
+                .{ .Seq = .{ .len = 0 } },
+                .{ .SeqEnd = {} },
+            },
+            .want = std.fifo.LinearFifo(u32, .Slice).init(&[_]u32{}),
+        },
+        .{
+            .name = "non-empty",
+            .tokens = &.{
+                .{ .Seq = .{ .len = 8 } },
+                .{ .U32 = 1 },
+                .{ .U32 = 2 },
+                .{ .U32 = 3 },
+                .{ .U32 = 4 },
+                .{ .U32 = 5 },
+                .{ .U32 = 6 },
+                .{ .U32 = 7 },
+                .{ .U32 = 8 },
+                .{ .SeqEnd = {} },
+            },
+            .want = blk: {
+                var want = std.fifo.LinearFifo(u32, .Slice).init(&buf);
+                want.writeAssumeCapacity(&[_]u32{ 1, 2, 3, 4, 1, 2, 3, 4 });
+                want.discard(4);
+                want.writeAssumeCapacity(&[_]u32{ 5, 6, 7, 8 });
+                break :blk want;
+            },
+        },
+    };
+
+    const Deserializer = testing.DefaultDeserializer.@"getty.Deserializer";
+
+    inline for (tests) |t| {
+        const Want = @TypeOf(t.want);
+
+        const got = try testing.deserialize(std.testing.allocator, t.name, Self, Want, t.tokens);
+        defer free(std.testing.allocator, Deserializer, got);
+
+        try testing.expectEqual(t.name, t.want.readableLength(), got.readableLength());
+
+        for (0..t.want.readableLength()) |i| {
+            try testing.expectEqual(t.name, t.want.peekItem(i), got.peekItem(i));
+        }
+    }
+}
+
+test "deserialize - std.LinearFifo (dynamic)" {
+    const tests = .{
+        .{
+            .name = "empty",
+            .tokens = &.{
+                .{ .Seq = .{ .len = 0 } },
+                .{ .SeqEnd = {} },
+            },
+            .want = std.fifo.LinearFifo(u32, .Dynamic).init(std.testing.allocator),
+        },
+        .{
+            .name = "non-empty",
+            .tokens = &.{
+                .{ .Seq = .{ .len = 8 } },
+                .{ .U32 = 1 },
+                .{ .U32 = 2 },
+                .{ .U32 = 3 },
+                .{ .U32 = 4 },
+                .{ .U32 = 5 },
+                .{ .U32 = 6 },
+                .{ .U32 = 7 },
+                .{ .U32 = 8 },
+                .{ .SeqEnd = {} },
+            },
+            .want = blk: {
+                var want = std.fifo.LinearFifo(u32, .Dynamic).init(std.testing.allocator);
+                try want.write(&[_]u32{ 1, 2, 3, 4, 1, 2, 3, 4 });
+                want.discard(4);
+                try want.write(&[_]u32{ 5, 6, 7, 8 });
+                break :blk want;
+            },
+        },
+    };
+
+    const Deserializer = testing.DefaultDeserializer.@"getty.Deserializer";
+
+    inline for (tests) |t| {
+        defer t.want.deinit();
+
+        const Want = @TypeOf(t.want);
+
+        const got = try testing.deserialize(std.testing.allocator, t.name, Self, Want, t.tokens);
+        defer free(std.testing.allocator, Deserializer, got);
+
+        try testing.expectEqual(t.name, t.want.readableLength(), got.readableLength());
+
+        for (0..t.want.readableLength()) |i| {
+            try testing.expectEqual(t.name, t.want.peekItem(i), got.peekItem(i));
+        }
+    }
+}

--- a/src/de/blocks/priority_dequeue.zig
+++ b/src/de/blocks/priority_dequeue.zig
@@ -1,0 +1,125 @@
+const std = @import("std");
+
+const getty_free = @import("../free.zig").free;
+const PriorityDequeueVisitor = @import("../impls/visitor/priority_dequeue.zig").Visitor;
+const testing = @import("../testing.zig");
+
+const Self = @This();
+
+/// Specifies all types that can be deserialized by this block.
+pub fn is(
+    /// The type being deserialized into.
+    comptime T: type,
+) bool {
+    return comptime std.mem.startsWith(u8, @typeName(T), "priority_dequeue.PriorityDequeue");
+}
+
+/// Specifies the deserialization process for types relevant to this block.
+pub fn deserialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
+    /// The type being deserialized into.
+    comptime T: type,
+    /// A `getty.Deserializer` interface value.
+    deserializer: anytype,
+    /// A `getty.de.Visitor` interface value.
+    visitor: anytype,
+) !@TypeOf(visitor).Value {
+    _ = T;
+
+    return try deserializer.deserializeSeq(allocator, visitor);
+}
+
+/// Returns a type that implements `getty.de.Visitor`.
+pub fn Visitor(
+    /// The type being deserialized into.
+    comptime T: type,
+) type {
+    return PriorityDequeueVisitor(T);
+}
+
+/// Frees resources allocated by Getty during deserialization.
+pub fn free(
+    /// A memory allocator.
+    allocator: std.mem.Allocator,
+    /// A `getty.Deserializer` interface type.
+    comptime Deserializer: type,
+    /// A value to deallocate.
+    value: anytype,
+) void {
+    var mut = value;
+    var it = mut.iterator();
+    while (it.next()) |elem| {
+        getty_free(allocator, Deserializer, elem);
+    }
+    value.deinit();
+}
+
+fn lessThan(context: void, a: i32, b: i32) std.math.Order {
+    _ = context;
+    return std.math.order(a, b);
+}
+
+test "deserialize - std.PriorityDequeue" {
+    const PDQ = std.PriorityDequeue(i32, void, lessThan);
+
+    const tests = .{
+        .{
+            .name = "empty",
+            .tokens = &.{
+                .{ .Seq = .{ .len = 0 } },
+                .{ .SeqEnd = {} },
+            },
+            .want = PDQ.init(std.testing.allocator, {}),
+        },
+        .{
+            .name = "non-empty",
+            .tokens = &.{
+                .{ .Seq = .{ .len = 4 } },
+                .{ .I32 = 1 },
+                .{ .I32 = 3 },
+                .{ .I32 = 2 },
+                .{ .I32 = 4 },
+                .{ .SeqEnd = {} },
+            },
+            .want = blk: {
+                var want = PDQ.init(std.testing.allocator, {});
+                try want.add(3);
+                try want.add(1);
+                try want.add(2);
+                try want.add(4);
+                break :blk want;
+            },
+        },
+    };
+
+    const Deserializer = testing.DefaultDeserializer.@"getty.Deserializer";
+
+    inline for (tests) |t| {
+        defer free(std.testing.allocator, Deserializer, t.want);
+
+        const Want = @TypeOf(t.want);
+        const got = try testing.deserialize(std.testing.allocator, t.name, Self, Want, t.tokens);
+        defer free(std.testing.allocator, Deserializer, got);
+
+        // Check that the deques' lengths match.
+        try testing.expectEqual(t.name, t.want.count(), got.count());
+
+        var want_it = blk: {
+            var mut = t.want;
+            break :blk mut.iterator();
+        };
+
+        var got_it = blk: {
+            var mut = got;
+            break :blk mut.iterator();
+        };
+
+        while (want_it.next()) |elem| {
+            var got_elem = got_it.next();
+
+            // Check that the deques' elements match.
+            try testing.expectEqual(t.name, elem, got_elem.?);
+        }
+    }
+}

--- a/src/de/blocks/priority_queue.zig
+++ b/src/de/blocks/priority_queue.zig
@@ -1,0 +1,125 @@
+const std = @import("std");
+
+const getty_free = @import("../free.zig").free;
+const PriorityQueueVisitor = @import("../impls/visitor/priority_queue.zig").Visitor;
+const testing = @import("../testing.zig");
+
+const Self = @This();
+
+/// Specifies all types that can be deserialized by this block.
+pub fn is(
+    /// The type being deserialized into.
+    comptime T: type,
+) bool {
+    return comptime std.mem.startsWith(u8, @typeName(T), "priority_queue.PriorityQueue");
+}
+
+/// Specifies the deserialization process for types relevant to this block.
+pub fn deserialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
+    /// The type being deserialized into.
+    comptime T: type,
+    /// A `getty.Deserializer` interface value.
+    deserializer: anytype,
+    /// A `getty.de.Visitor` interface value.
+    visitor: anytype,
+) !@TypeOf(visitor).Value {
+    _ = T;
+
+    return try deserializer.deserializeSeq(allocator, visitor);
+}
+
+/// Returns a type that implements `getty.de.Visitor`.
+pub fn Visitor(
+    /// The type being deserialized into.
+    comptime T: type,
+) type {
+    return PriorityQueueVisitor(T);
+}
+
+/// Frees resources allocated by Getty during deserialization.
+pub fn free(
+    /// A memory allocator.
+    allocator: std.mem.Allocator,
+    /// A `getty.Deserializer` interface type.
+    comptime Deserializer: type,
+    /// A value to deallocate.
+    value: anytype,
+) void {
+    var mut = value;
+    var it = mut.iterator();
+    while (it.next()) |elem| {
+        getty_free(allocator, Deserializer, elem);
+    }
+    value.deinit();
+}
+
+fn lessThan(context: void, a: i32, b: i32) std.math.Order {
+    _ = context;
+    return std.math.order(a, b);
+}
+
+test "deserialize - std.PriorityQueue" {
+    const PQ = std.PriorityQueue(i32, void, lessThan);
+
+    const tests = .{
+        .{
+            .name = "empty",
+            .tokens = &.{
+                .{ .Seq = .{ .len = 0 } },
+                .{ .SeqEnd = {} },
+            },
+            .want = PQ.init(std.testing.allocator, {}),
+        },
+        .{
+            .name = "non-empty",
+            .tokens = &.{
+                .{ .Seq = .{ .len = 4 } },
+                .{ .I32 = 1 },
+                .{ .I32 = 3 },
+                .{ .I32 = 2 },
+                .{ .I32 = 4 },
+                .{ .SeqEnd = {} },
+            },
+            .want = blk: {
+                var want = PQ.init(std.testing.allocator, {});
+                try want.add(3);
+                try want.add(1);
+                try want.add(2);
+                try want.add(4);
+                break :blk want;
+            },
+        },
+    };
+
+    const Deserializer = testing.DefaultDeserializer.@"getty.Deserializer";
+
+    inline for (tests) |t| {
+        defer free(std.testing.allocator, Deserializer, t.want);
+
+        const Want = @TypeOf(t.want);
+        const got = try testing.deserialize(std.testing.allocator, t.name, Self, Want, t.tokens);
+        defer free(std.testing.allocator, Deserializer, got);
+
+        // Check that the queues' lengths match.
+        try testing.expectEqual(t.name, t.want.count(), got.count());
+
+        var want_it = blk: {
+            var mut = t.want;
+            break :blk mut.iterator();
+        };
+
+        var got_it = blk: {
+            var mut = got;
+            break :blk mut.iterator();
+        };
+
+        while (want_it.next()) |elem| {
+            var got_elem = got_it.next();
+
+            // Check that the queues' elements match.
+            try testing.expectEqual(t.name, elem, got_elem.?);
+        }
+    }
+}

--- a/src/de/error.zig
+++ b/src/de/error.zig
@@ -5,6 +5,8 @@ const std = @import("std");
 /// This error set must always be included in a `getty.Deserializer`
 /// implementation's error set.
 pub const Error = std.mem.Allocator.Error || error{
+    /// Overflow for math operations
+    Overflow,
     DuplicateField,
     InvalidLength,
     InvalidType,

--- a/src/de/impls/visitor/array.zig
+++ b/src/de/impls/visitor/array.zig
@@ -24,10 +24,8 @@ pub fn Visitor(comptime Array: type) type {
 
             errdefer {
                 if (allocator) |alloc| {
-                    if (array.len > 0) {
-                        for (0..seen) |i| {
-                            free(alloc, Deserializer, array[i]);
-                        }
+                    for (array[0..seen]) |v| {
+                        free(alloc, Deserializer, v);
                     }
                 }
             }
@@ -58,7 +56,7 @@ pub fn Visitor(comptime Array: type) type {
                 var string: Value = undefined;
 
                 if (input.len == string.len) {
-                    std.mem.copy(u8, &string, input);
+                    @memcpy(&string, input);
                     return string;
                 }
             }

--- a/src/de/impls/visitor/enum_multiset.zig
+++ b/src/de/impls/visitor/enum_multiset.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+
+const free = @import("../../free.zig").free;
+const VisitorInterface = @import("../../interfaces/visitor.zig").Visitor;
+
+pub fn Visitor(comptime EnumMultiset: type) type {
+    return struct {
+        const Self = @This();
+
+        pub usingnamespace VisitorInterface(
+            Self,
+            Value,
+            .{
+                .visitSeq = visitSeq,
+                .visitMap = visitMap,
+            },
+        );
+
+        const Value = EnumMultiset;
+
+        fn visitSeq(_: Self, allocator: ?std.mem.Allocator, comptime Deserializer: type, seq: anytype) Deserializer.Error!Value {
+            var multiset = Value.initEmpty();
+            errdefer free(allocator.?, Deserializer, multiset);
+
+            const K = std.meta.FieldType(Value, .counts).Key;
+
+            while (try seq.nextElement(allocator, K)) |key| {
+                // defer free(allocator.?, Deserializer, key);
+                try multiset.add(key, 1);
+            }
+
+            return multiset;
+        }
+
+        fn visitMap(_: Self, allocator: ?std.mem.Allocator, comptime Deserializer: type, map: anytype) Deserializer.Error!Value {
+            var multiset = Value.initEmpty();
+            errdefer free(allocator.?, Deserializer, multiset);
+
+            const K = std.meta.FieldType(Value, .counts).Key;
+            const V = std.meta.FieldType(Value, .counts).Value;
+
+            while (try map.nextKey(allocator, K)) |k| {
+                defer if (map.isKeyAllocated(@TypeOf(k))) {
+                    free(allocator.?, Deserializer, k);
+                };
+
+                const v = try map.nextValue(allocator, V);
+                errdefer free(allocator.?, Deserializer, v);
+
+                try multiset.add(k, v);
+            }
+
+            return multiset;
+        }
+    };
+}

--- a/src/de/impls/visitor/indexed_array.zig
+++ b/src/de/impls/visitor/indexed_array.zig
@@ -1,0 +1,50 @@
+const std = @import("std");
+
+const free = @import("../../free.zig").free;
+const VisitorInterface = @import("../../interfaces/visitor.zig").Visitor;
+
+pub fn Visitor(comptime IndexedArray: type) type {
+    return struct {
+        const Self = @This();
+
+        pub usingnamespace VisitorInterface(
+            Self,
+            Value,
+            .{ .visitSeq = visitSeq },
+        );
+
+        const Value = IndexedArray;
+
+        fn visitSeq(_: Self, allocator: ?std.mem.Allocator, comptime Deserializer: type, seq: anytype) Deserializer.Error!Value {
+            var array = Value.initUndefined();
+            var seen: usize = 0;
+
+            const V = Value.Value;
+
+            errdefer {
+                if (allocator) |alloc| {
+                    for (array.values[0..seen]) |v| {
+                        free(alloc, Deserializer, v);
+                    }
+                }
+            }
+
+            for (&array.values) |*value| {
+                if (try seq.nextElement(allocator, V)) |v| {
+                    value.* = v;
+                    seen += 1;
+                } else {
+                    // End of sequence was reached early.
+                    return error.InvalidLength;
+                }
+            }
+
+            // Expected end of sequence, but found an element.
+            if ((try seq.nextElement(allocator, V)) != null) {
+                return error.InvalidLength;
+            }
+
+            return array;
+        }
+    };
+}

--- a/src/de/impls/visitor/indexed_map.zig
+++ b/src/de/impls/visitor/indexed_map.zig
@@ -1,0 +1,36 @@
+const std = @import("std");
+
+const free = @import("../../free.zig").free;
+const VisitorInterface = @import("../../interfaces/visitor.zig").Visitor;
+
+pub fn Visitor(comptime IndexedMap: type) type {
+    return struct {
+        const Self = @This();
+
+        pub usingnamespace VisitorInterface(
+            Self,
+            Value,
+            .{ .visitMap = visitMap },
+        );
+
+        const Value = IndexedMap;
+
+        fn visitMap(_: Self, allocator: ?std.mem.Allocator, comptime Deserializer: type, map: anytype) Deserializer.Error!Value {
+            var m = Value{};
+            errdefer free(allocator.?, Deserializer, m);
+
+            while (try map.nextKey(allocator, Value.Key)) |k| {
+                defer if (map.isKeyAllocated(@TypeOf(k))) {
+                    free(allocator.?, Deserializer, k);
+                };
+
+                const v = try map.nextValue(allocator, Value.Value);
+                errdefer free(allocator.?, Deserializer, v);
+
+                m.put(k, v);
+            }
+
+            return m;
+        }
+    };
+}

--- a/src/de/impls/visitor/indexed_set.zig
+++ b/src/de/impls/visitor/indexed_set.zig
@@ -1,0 +1,30 @@
+const std = @import("std");
+
+const free = @import("../../free.zig").free;
+const VisitorInterface = @import("../../interfaces/visitor.zig").Visitor;
+
+pub fn Visitor(comptime IndexedSet: type) type {
+    return struct {
+        const Self = @This();
+
+        pub usingnamespace VisitorInterface(
+            Self,
+            Value,
+            .{ .visitSeq = visitSeq },
+        );
+
+        const Value = IndexedSet;
+
+        fn visitSeq(_: Self, allocator: ?std.mem.Allocator, comptime Deserializer: type, seq: anytype) Deserializer.Error!Value {
+            var set = Value.initEmpty();
+            errdefer free(allocator.?, Deserializer, set);
+
+            while (try seq.nextElement(allocator, Value.Key)) |k| {
+                defer free(allocator.?, Deserializer, k);
+                set.insert(k);
+            }
+
+            return set;
+        }
+    };
+}

--- a/src/de/impls/visitor/linear_fifo.zig
+++ b/src/de/impls/visitor/linear_fifo.zig
@@ -1,0 +1,78 @@
+const std = @import("std");
+
+const free = @import("../../free.zig").free;
+const VisitorInterface = @import("../../interfaces/visitor.zig").Visitor;
+
+pub fn Visitor(comptime LinearFifo: type) type {
+    return struct {
+        const Self = @This();
+
+        pub usingnamespace VisitorInterface(
+            Self,
+            Value,
+            .{ .visitSeq = visitSeq },
+        );
+
+        const Value = LinearFifo;
+
+        fn visitSeq(_: Self, allocator: ?std.mem.Allocator, comptime Deserializer: type, seq: anytype) Deserializer.Error!Value {
+            if (is_buffer_static) {
+                var fifo = Value.init();
+                errdefer free(allocator.?, Deserializer, fifo);
+
+                for (0..fifo.buf.len) |_| {
+                    if (try seq.nextElement(allocator, Child)) |elem| {
+                        fifo.writeItemAssumeCapacity(elem);
+                    } else {
+                        break;
+                    }
+                } else if (try seq.nextElement(allocator, Child) != null) {
+                    // Expected end of sequence, but found an element.
+                    return error.InvalidLength;
+                }
+
+                return fifo;
+            } else if (is_buffer_dynamic) {
+                if (allocator == null) {
+                    return error.MissingAllocator;
+                }
+
+                const a = allocator.?;
+
+                var fifo = Value.init(a);
+                errdefer free(a, Deserializer, fifo);
+
+                while (try seq.nextElement(a, Child)) |elem| {
+                    errdefer free(a, Deserializer, elem);
+                    try fifo.writeItem(elem);
+                }
+
+                return fifo;
+            } else {
+                if (allocator == null) {
+                    return error.MissingAllocator;
+                }
+
+                const a = allocator.?;
+
+                var list = std.ArrayList(Child).init(a);
+                errdefer free(a, Deserializer, list);
+
+                while (try seq.nextElement(a, Child)) |elem| {
+                    errdefer free(a, Deserializer, elem);
+                    try list.append(elem);
+                }
+
+                var fifo = Value.init(try list.toOwnedSlice());
+                fifo.count = fifo.buf.len;
+
+                return fifo;
+            }
+        }
+
+        const is_buffer_dynamic = std.meta.FieldType(Value, .allocator) != void;
+        const is_buffer_static = @typeInfo(std.meta.FieldType(Value, .buf)) == .Array;
+
+        const Child = std.meta.Child(std.meta.FieldType(Value, .buf));
+    };
+}

--- a/src/de/impls/visitor/priority_dequeue.zig
+++ b/src/de/impls/visitor/priority_dequeue.zig
@@ -1,0 +1,42 @@
+const std = @import("std");
+
+const free = @import("../../free.zig").free;
+const VisitorInterface = @import("../../interfaces/visitor.zig").Visitor;
+
+pub fn Visitor(comptime PriorityDequeue: type) type {
+    return struct {
+        const Self = @This();
+
+        pub usingnamespace VisitorInterface(
+            Self,
+            Value,
+            .{ .visitSeq = visitSeq },
+        );
+
+        const Value = PriorityDequeue;
+
+        fn visitSeq(_: Self, allocator: ?std.mem.Allocator, comptime Deserializer: type, seq: anytype) Deserializer.Error!Value {
+            if (allocator == null) {
+                return error.MissingAllocator;
+            }
+
+            const a = allocator.?;
+
+            const T = std.meta.Child(std.meta.FieldType(Value, .items));
+            const Context = std.meta.FieldType(Value, .context);
+
+            if (@sizeOf(Context) != 0) {
+                @compileError("non void context is not supported");
+            }
+
+            var deque = Value.init(a, undefined);
+            errdefer free(a, Deserializer, deque);
+
+            while (try seq.nextElement(a, T)) |elem| {
+                try deque.add(elem);
+            }
+
+            return deque;
+        }
+    };
+}

--- a/src/de/impls/visitor/priority_queue.zig
+++ b/src/de/impls/visitor/priority_queue.zig
@@ -1,0 +1,42 @@
+const std = @import("std");
+
+const free = @import("../../free.zig").free;
+const VisitorInterface = @import("../../interfaces/visitor.zig").Visitor;
+
+pub fn Visitor(comptime PriorityQueue: type) type {
+    return struct {
+        const Self = @This();
+
+        pub usingnamespace VisitorInterface(
+            Self,
+            Value,
+            .{ .visitSeq = visitSeq },
+        );
+
+        const Value = PriorityQueue;
+
+        fn visitSeq(_: Self, allocator: ?std.mem.Allocator, comptime Deserializer: type, seq: anytype) Deserializer.Error!Value {
+            if (allocator == null) {
+                return error.MissingAllocator;
+            }
+
+            const a = allocator.?;
+
+            const T = std.meta.Child(std.meta.FieldType(Value, .items));
+            const Context = std.meta.FieldType(Value, .context);
+
+            if (@sizeOf(Context) != 0) {
+                @compileError("non void context is not supported");
+            }
+
+            var queue = Value.init(a, undefined);
+            errdefer free(a, Deserializer, queue);
+
+            while (try seq.nextElement(a, T)) |elem| {
+                try queue.add(elem);
+            }
+
+            return queue;
+        }
+    };
+}

--- a/src/de/tuples.zig
+++ b/src/de/tuples.zig
@@ -46,9 +46,9 @@ pub const dt = .{
 
     // Covers the following types:
     //
-    //   - std.EnumMultiset
-    //   - std.BoundedEnumMultiset
-    blocks.BoundedEnumMultiset,
+    //   - std.EnumMap
+    //   - std.IndexedMap
+    blocks.IndexedMap,
 
     // Covers the following types:
     //

--- a/src/de/tuples.zig
+++ b/src/de/tuples.zig
@@ -67,6 +67,7 @@ pub const dt = .{
     //   - std.PackedIntSliceEndian
     blocks.PackedIntArray,
 
+    blocks.PriorityQueue,
     blocks.SemanticVersion,
     blocks.SinglyLinkedList,
     blocks.TailQueue,

--- a/src/de/tuples.zig
+++ b/src/de/tuples.zig
@@ -40,6 +40,18 @@ pub const dt = .{
 
     // Covers the following types:
     //
+    //   - std.EnumArray
+    //   - std.IndexedArray
+    blocks.IndexedArray,
+
+    // Covers the following types:
+    //
+    //   - std.EnumMultiset
+    //   - std.BoundedEnumMultiset
+    blocks.BoundedEnumMultiset,
+
+    // Covers the following types:
+    //
     //   - std.HashMap
     //   - std.HashMapUnmanaged
     //   - std.AutoHashMap

--- a/src/de/tuples.zig
+++ b/src/de/tuples.zig
@@ -46,6 +46,12 @@ pub const dt = .{
 
     // Covers the following types:
     //
+    //   - std.EnumSet
+    //   - std.IndexedSet
+    blocks.IndexedSet,
+
+    // Covers the following types:
+    //
     //   - std.EnumMap
     //   - std.IndexedMap
     blocks.IndexedMap,

--- a/src/de/tuples.zig
+++ b/src/de/tuples.zig
@@ -58,6 +58,12 @@ pub const dt = .{
 
     // Covers the following types:
     //
+    //   - std.EnumMultiset
+    //   - std.BoundedEnumMultiset
+    blocks.BoundedEnumMultiset,
+
+    // Covers the following types:
+    //
     //   - std.HashMap
     //   - std.HashMapUnmanaged
     //   - std.AutoHashMap

--- a/src/de/tuples.zig
+++ b/src/de/tuples.zig
@@ -68,6 +68,7 @@ pub const dt = .{
     blocks.PackedIntArray,
 
     blocks.PriorityQueue,
+    blocks.PriorityDequeue,
     blocks.SemanticVersion,
     blocks.SinglyLinkedList,
     blocks.TailQueue,

--- a/src/de/tuples.zig
+++ b/src/de/tuples.zig
@@ -96,6 +96,7 @@ pub const dt = .{
     blocks.SemanticVersion,
     blocks.SinglyLinkedList,
     blocks.TailQueue,
+    blocks.LinearFifo,
     blocks.SegmentedList,
 
     ////////////////////////////////////////////////////////////////////////////

--- a/src/ser/blocks.zig
+++ b/src/ser/blocks.zig
@@ -135,6 +135,9 @@ pub const SemanticVersion = @import("blocks/semantic_version.zig");
 /// Serialization block for `std.PriorityQueue` values.
 pub const PriorityQueue = @import("blocks/priority_queue.zig");
 
+/// Serialization block for `std.PriorityDequeue` values.
+pub const PriorityDequeue = @import("blocks/priority_dequeue.zig");
+
 /// Serialization block for `std.SinglyLinkedList` values.
 pub const SinglyLinkedList = @import("blocks/singly_linked_list.zig");
 

--- a/src/ser/blocks.zig
+++ b/src/ser/blocks.zig
@@ -105,11 +105,11 @@ pub const EnumArray = _IndexedArray;
 /// Serialization block for `std.IndexedArray` values.
 pub const IndexedArray = _IndexedArray;
 
-/// Serialization block for `std.BoundedEnumMultiset` values.
-pub const BoundedEnumMultiset = _EnumMultiset;
+/// Serialization block for `std.EnumMap` values.
+pub const EnumMap = _IndexedMap;
 
-/// Serialization block for `std.EnumMultiset` values.
-pub const EnumMultiset = _EnumMultiset;
+/// Serialization block for `std.IndexedMap` values.
+pub const IndexedMap = _IndexedMap;
 
 /// Serialization block for `std.HashMap` values.
 pub const HashMap = _HashMap;
@@ -196,4 +196,4 @@ const _ArrayListAligned = @import("blocks/array_list_aligned.zig");
 const _HashMap = @import("blocks/hash_map.zig");
 const _PackedIntEndian = @import("blocks/packed_int_endian.zig");
 const _IndexedArray = @import("blocks/indexed_array.zig");
-const _EnumMultiset = @import("blocks/enum_multiset.zig");
+const _IndexedMap = @import("blocks/indexed_map.zig");

--- a/src/ser/blocks.zig
+++ b/src/ser/blocks.zig
@@ -132,6 +132,9 @@ pub const PackedIntSliceEndian = _PackedIntEndian;
 /// Serialization block for `std.SemanticVersion`.
 pub const SemanticVersion = @import("blocks/semantic_version.zig");
 
+/// Serialization block for `std.PriorityQueue` values.
+pub const PriorityQueue = @import("blocks/priority_queue.zig");
+
 /// Serialization block for `std.SinglyLinkedList` values.
 pub const SinglyLinkedList = @import("blocks/singly_linked_list.zig");
 

--- a/src/ser/blocks.zig
+++ b/src/ser/blocks.zig
@@ -105,6 +105,12 @@ pub const EnumArray = _IndexedArray;
 /// Serialization block for `std.IndexedArray` values.
 pub const IndexedArray = _IndexedArray;
 
+/// Serialization block for `std.EnumSet` values.
+pub const EnumSet = _IndexedSet;
+
+/// Serialization block for `std.IndexedSet` values.
+pub const IndexedSet = _IndexedSet;
+
 /// Serialization block for `std.EnumMap` values.
 pub const EnumMap = _IndexedMap;
 
@@ -196,4 +202,5 @@ const _ArrayListAligned = @import("blocks/array_list_aligned.zig");
 const _HashMap = @import("blocks/hash_map.zig");
 const _PackedIntEndian = @import("blocks/packed_int_endian.zig");
 const _IndexedArray = @import("blocks/indexed_array.zig");
+const _IndexedSet = @import("blocks/indexed_set.zig");
 const _IndexedMap = @import("blocks/indexed_map.zig");

--- a/src/ser/blocks.zig
+++ b/src/ser/blocks.zig
@@ -117,6 +117,12 @@ pub const EnumMap = _IndexedMap;
 /// Serialization block for `std.IndexedMap` values.
 pub const IndexedMap = _IndexedMap;
 
+/// Serialization block for `std.EnumMultiset` values.
+pub const EnumMultiset = _EnumMultiset;
+
+/// Serialization block for `std.IndexedSet` values.
+pub const BoundedEnumMultiset = _EnumMultiset;
+
 /// Serialization block for `std.HashMap` values.
 pub const HashMap = _HashMap;
 
@@ -204,3 +210,4 @@ const _PackedIntEndian = @import("blocks/packed_int_endian.zig");
 const _IndexedArray = @import("blocks/indexed_array.zig");
 const _IndexedSet = @import("blocks/indexed_set.zig");
 const _IndexedMap = @import("blocks/indexed_map.zig");
+const _EnumMultiset = @import("blocks/enum_multiset.zig");

--- a/src/ser/blocks.zig
+++ b/src/ser/blocks.zig
@@ -183,6 +183,9 @@ pub const StringHashMapUnmanaged = _HashMap;
 /// Serialization block for `std.TailQueue`.
 pub const TailQueue = @import("blocks/tail_queue.zig");
 
+/// Serialization block for `std.LinearFifo`.
+pub const LinearFifo = @import("blocks/linear_fifo.zig");
+
 /// Serialization block for `std.SegmentedList`.
 pub const SegmentedList = @import("blocks/segmented_list.zig");
 

--- a/src/ser/blocks.zig
+++ b/src/ser/blocks.zig
@@ -99,6 +99,18 @@ pub const DynamicBitSet = @import("blocks/dynamic_bit_set.zig");
 /// Serialization block for `std.DynamicBitSetUnmanaged` values.
 pub const DynamicBitSetUnmanaged = @import("blocks/dynamic_bit_set_unmanaged.zig");
 
+/// Serialization block for `std.EnumArray` values.
+pub const EnumArray = _IndexedArray;
+
+/// Serialization block for `std.IndexedArray` values.
+pub const IndexedArray = _IndexedArray;
+
+/// Serialization block for `std.BoundedEnumMultiset` values.
+pub const BoundedEnumMultiset = _EnumMultiset;
+
+/// Serialization block for `std.EnumMultiset` values.
+pub const EnumMultiset = _EnumMultiset;
+
 /// Serialization block for `std.HashMap` values.
 pub const HashMap = _HashMap;
 
@@ -183,3 +195,5 @@ pub const Union = @import("blocks/union.zig");
 const _ArrayListAligned = @import("blocks/array_list_aligned.zig");
 const _HashMap = @import("blocks/hash_map.zig");
 const _PackedIntEndian = @import("blocks/packed_int_endian.zig");
+const _IndexedArray = @import("blocks/indexed_array.zig");
+const _EnumMultiset = @import("blocks/enum_multiset.zig");

--- a/src/ser/blocks/enum_multiset.zig
+++ b/src/ser/blocks/enum_multiset.zig
@@ -1,0 +1,115 @@
+const std = @import("std");
+
+const getty_serialize = @import("../serialize.zig").serialize;
+const blocks = @import("../blocks.zig");
+const t = @import("../testing.zig");
+
+/// Specifies all types that can be serialized by this block.
+pub fn is(
+    /// The type of a value being serialized.
+    comptime T: type,
+) bool {
+    const is_bounded_enum_multiset = comptime std.mem.startsWith(u8, @typeName(T), "enums.BoundedEnumMultiset");
+    const is_enum_multiset = comptime std.mem.startsWith(u8, @typeName(T), "enums.EnumMultiset");
+
+    return is_bounded_enum_multiset or is_enum_multiset;
+}
+
+/// Specifies the serialization process for values relevant to this block.
+pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
+    /// A value being serialized.
+    value: anytype,
+    /// A `getty.Serializer` interface value.
+    serializer: anytype,
+) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+    _ = allocator;
+    const K = std.meta.FieldType(@TypeOf(value), .counts).Key;
+    const fields = std.meta.fields(K);
+
+    // Store the keys contained in the multiset so we don't need to find them again.
+    var keys: [fields.len]K = undefined;
+    // Count the number of non-zero entries.
+    var count: usize = 0;
+    inline for (fields) |field| {
+        const key = @as(K, @enumFromInt(field.value));
+        if (value.contains(key)) {
+            keys[count] = key;
+            count += 1;
+        }
+    }
+
+    var m = try serializer.serializeMap(count);
+    const map = m.map();
+
+    for (keys[0..count]) |key| {
+        try map.serializeEntry(key, value.getCount(key));
+    }
+
+    return try map.end();
+}
+
+const Color = enum { red, blue, yellow, green, orange, violet };
+
+test "serialize - std.BoundedEnumMultiset" {
+    var multiset = std.enums.BoundedEnumMultiset(Color, u8).initEmpty();
+
+    try t.run(null, serialize, multiset, &.{
+        .{ .Map = .{ .len = 0 } },
+        .{ .MapEnd = {} },
+    });
+
+    try multiset.add(.red, 1);
+    try multiset.add(.blue, 2);
+    try multiset.add(.yellow, 3);
+    try multiset.add(.orange, 2);
+
+    try t.run(null, serialize, multiset, &.{
+        .{ .Map = .{ .len = 4 } },
+        .{ .Enum = {} },
+        .{ .String = "red" },
+        .{ .U8 = 1 },
+        .{ .Enum = {} },
+        .{ .String = "blue" },
+        .{ .U8 = 2 },
+        .{ .Enum = {} },
+        .{ .String = "yellow" },
+        .{ .U8 = 3 },
+        .{ .Enum = {} },
+        .{ .String = "orange" },
+        .{ .U8 = 2 },
+        .{ .MapEnd = {} },
+    });
+}
+
+test "serialize - std.EnumMultiset" {
+    var multiset = std.enums.EnumMultiset(Color).initEmpty();
+
+    try t.run(null, serialize, multiset, &.{
+        .{ .Map = .{ .len = 0 } },
+        .{ .MapEnd = {} },
+    });
+
+    try multiset.add(.red, 1);
+    try multiset.add(.blue, 2);
+    try multiset.add(.yellow, 4);
+    try multiset.add(.violet, 3);
+
+    try t.run(null, serialize, multiset, &.{
+        .{ .Map = .{ .len = 4 } },
+        .{ .Enum = {} },
+        .{ .String = "red" },
+        .{ .U64 = 1 },
+        .{ .Enum = {} },
+        .{ .String = "blue" },
+        .{ .U64 = 2 },
+        .{ .Enum = {} },
+        .{ .String = "yellow" },
+        .{ .U64 = 4 },
+        .{ .Enum = {} },
+        .{ .String = "violet" },
+        .{ .U64 = 3 },
+        .{ .MapEnd = {} },
+    });
+}

--- a/src/ser/blocks/indexed_array.zig
+++ b/src/ser/blocks/indexed_array.zig
@@ -1,0 +1,134 @@
+const std = @import("std");
+
+const getty_serialize = @import("../serialize.zig").serialize;
+const blocks = @import("../blocks.zig");
+const t = @import("../testing.zig");
+
+/// Specifies all types that can be serialized by this block.
+pub fn is(
+    /// The type of a value being serialized.
+    comptime T: type,
+) bool {
+    const is_indexed_array = comptime std.mem.startsWith(u8, @typeName(T), "enums.IndexedArray");
+    const is_enum_array = comptime std.mem.startsWith(u8, @typeName(T), "enums.EnumArray");
+
+    return is_indexed_array or is_enum_array;
+}
+
+/// Specifies the serialization process for values relevant to this block.
+pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
+    /// A value being serialized.
+    value: anytype,
+    /// A `getty.Serializer` interface value.
+    serializer: anytype,
+) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+    return try getty_serialize(allocator, value.values, serializer);
+}
+
+fn StringIndexer(comptime str_keys: []const []const u8) type {
+    if (str_keys.len == 0) {
+        return struct {
+            pub const Key = []const u8;
+            pub const count: usize = 0;
+            pub fn indexOf(k: Key) usize {
+                _ = k;
+                unreachable;
+            }
+            pub fn keyForIndex(i: usize) Key {
+                _ = i;
+                unreachable;
+            }
+        };
+    }
+
+    return struct {
+        pub const Key = []const u8;
+        pub const count: usize = str_keys.len;
+        pub fn indexOf(k: Key) usize {
+            for (str_keys, 0..) |key, i| {
+                if (std.mem.eql(u8, k, key)) {
+                    return i;
+                }
+            }
+            unreachable;
+        }
+        pub fn keyForIndex(i: usize) Key {
+            return str_keys[i];
+        }
+    };
+}
+
+test "serialize - std.IndexedArray" {
+    const Color = StringIndexer(&.{ "red", "yellow", "blue", "green", "orange", "violet" });
+
+    // empty
+    {
+        var array = std.enums.IndexedArray(StringIndexer(&.{}), u32, null).initFill(0);
+
+        try t.run(null, serialize, array, &.{
+            .{ .Seq = .{ .len = 0 } },
+            .{ .SeqEnd = {} },
+        });
+    }
+
+    // non-empty
+    {
+        var array = std.enums.IndexedArray(Color, u32, null).initFill(0);
+
+        array.set("red", 1);
+        array.set("blue", 2);
+        array.set("yellow", 3);
+        array.set("orange", 2);
+
+        try t.run(null, serialize, array, &.{
+            .{ .Seq = .{ .len = 6 } },
+            .{ .U32 = 1 },
+            .{ .U32 = 3 },
+            .{ .U32 = 2 },
+            .{ .U32 = 0 },
+            .{ .U32 = 2 },
+            .{ .U32 = 0 },
+            .{ .SeqEnd = {} },
+        });
+    }
+}
+
+test "serialize - std.EnumArray" {
+    const Color = enum { red, yellow, blue, green, orange, violet };
+
+    // empty
+    // std.EnumIndexer, which is used internally by std.EnumArray,
+    // fails to compile on an empty enum due to field access occuring
+    // before checking field length.
+    // {
+    //     var array = std.enums.EnumArray(enum {}, u32).initFill(0);
+
+    //     try t.run(null, serialize, array, &.{
+    //         .{ .Seq = .{ .len = 0 } },
+    //         .{ .SeqEnd = {} },
+    //     });
+    // }
+
+    // non-empty
+    {
+        var array = std.enums.EnumArray(Color, u32).initFill(0);
+
+        array.set(.red, 1);
+        array.set(.blue, 2);
+        array.set(.yellow, 3);
+        array.set(.orange, 2);
+
+        try t.run(null, serialize, array, &.{
+            .{ .Seq = .{ .len = 6 } },
+            .{ .U32 = 1 },
+            .{ .U32 = 3 },
+            .{ .U32 = 2 },
+            .{ .U32 = 0 },
+            .{ .U32 = 2 },
+            .{ .U32 = 0 },
+            .{ .SeqEnd = {} },
+        });
+    }
+}

--- a/src/ser/blocks/indexed_map.zig
+++ b/src/ser/blocks/indexed_map.zig
@@ -1,0 +1,178 @@
+const std = @import("std");
+
+const getty_serialize = @import("../serialize.zig").serialize;
+const blocks = @import("../blocks.zig");
+const t = @import("../testing.zig");
+
+/// Specifies all types that can be serialized by this block.
+pub fn is(
+    /// The type of a value being serialized.
+    comptime T: type,
+) bool {
+    const is_indexed_map = comptime std.mem.startsWith(u8, @typeName(T), "enums.IndexedMap");
+    const is_enum_map = comptime std.mem.startsWith(u8, @typeName(T), "enums.EnumMap");
+
+    return is_indexed_map or is_enum_map;
+}
+
+/// Specifies the serialization process for values relevant to this block.
+pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
+    /// A value being serialized.
+    value: anytype,
+    /// A `getty.Serializer` interface value.
+    serializer: anytype,
+) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+    _ = allocator;
+
+    var m = try serializer.serializeMap(value.count());
+    const map = m.map();
+
+    var mut = value;
+    var it = mut.iterator();
+    while (it.next()) |entry| {
+        try map.serializeEntry(entry.key, entry.value.*);
+    }
+
+    return try map.end();
+}
+
+fn StringIndexer(comptime str_keys: []const []const u8) type {
+    if (str_keys.len == 0) {
+        return struct {
+            pub const Key = []const u8;
+            pub const count: usize = 0;
+            pub fn indexOf(k: Key) usize {
+                _ = k;
+                unreachable;
+            }
+            pub fn keyForIndex(i: usize) Key {
+                _ = i;
+                unreachable;
+            }
+        };
+    }
+
+    return struct {
+        pub const Key = []const u8;
+        pub const count: usize = str_keys.len;
+        pub fn indexOf(k: Key) usize {
+            for (str_keys, 0..) |key, i| {
+                if (std.mem.eql(u8, k, key)) {
+                    return i;
+                }
+            }
+            unreachable;
+        }
+        pub fn keyForIndex(i: usize) Key {
+            return str_keys[i];
+        }
+    };
+}
+
+test "serialize - std.IndexedMap" {
+    const Color = StringIndexer(&.{ "red", "yellow", "blue", "green", "orange", "violet" });
+
+    // zero-sized
+    // std.IndexedMap's put function directly accesses its internal
+    // dense array without checking length of the array. Since the
+    // length of the array is determined by the Indexer, this will
+    // fail to compile with "error: indexing into empty array is not
+    // allowed" on an empty index.
+    // {
+    //     var map = std.enums.IndexedMap(StringIndexer(&.{}), u32, null){};
+
+    //     try t.run(null, serialize, map, &.{
+    //         .{ .Map = .{ .len = 0 } },
+    //         .{ .MapEnd = {} },
+    //     });
+    // }
+
+    // empty
+    {
+        var map = std.enums.IndexedMap(Color, u32, null){};
+
+        try t.run(null, serialize, map, &.{
+            .{ .Map = .{ .len = 0 } },
+            .{ .MapEnd = {} },
+        });
+    }
+
+    // non-empty
+    {
+        var map = std.enums.IndexedMap(Color, u32, null){};
+
+        map.put("red", 1);
+        map.put("blue", 2);
+        map.put("yellow", 3);
+        map.put("orange", 2);
+
+        try t.run(null, serialize, map, &.{
+            .{ .Map = .{ .len = 4 } },
+            .{ .String = "red" },
+            .{ .U32 = 1 },
+            .{ .String = "yellow" },
+            .{ .U32 = 3 },
+            .{ .String = "blue" },
+            .{ .U32 = 2 },
+            .{ .String = "orange" },
+            .{ .U32 = 2 },
+            .{ .MapEnd = {} },
+        });
+    }
+}
+
+test "serialize - std.EnumMap" {
+    const Color = enum { red, yellow, blue, green, orange, violet };
+
+    // zero-sized
+    // std.EnumIndexer, which is used internally by std.EnumMap,
+    // fails to compile on an empty enum due to field access occuring
+    // before checking field length.
+    // {
+    //     var map = std.enums.EnumMap(enum {}, u32){};
+
+    //     try t.run(null, serialize, map, &.{
+    //         .{ .Map = .{ .len = 0 } },
+    //         .{ .MapEnd = {} },
+    //     });
+    // }
+
+    // empty
+    {
+        var map = std.enums.EnumMap(Color, u32){};
+
+        try t.run(null, serialize, map, &.{
+            .{ .Map = .{ .len = 0 } },
+            .{ .MapEnd = {} },
+        });
+    }
+
+    // non-empty
+    {
+        var map = std.enums.EnumMap(Color, u32){};
+
+        map.put(.red, 1);
+        map.put(.blue, 2);
+        map.put(.yellow, 3);
+        map.put(.orange, 2);
+
+        try t.run(null, serialize, map, &.{
+            .{ .Map = .{ .len = 4 } },
+            .{ .Enum = {} },
+            .{ .String = "red" },
+            .{ .U32 = 1 },
+            .{ .Enum = {} },
+            .{ .String = "yellow" },
+            .{ .U32 = 3 },
+            .{ .Enum = {} },
+            .{ .String = "blue" },
+            .{ .U32 = 2 },
+            .{ .Enum = {} },
+            .{ .String = "orange" },
+            .{ .U32 = 2 },
+            .{ .MapEnd = {} },
+        });
+    }
+}

--- a/src/ser/blocks/indexed_set.zig
+++ b/src/ser/blocks/indexed_set.zig
@@ -1,0 +1,200 @@
+const std = @import("std");
+
+const getty_serialize = @import("../serialize.zig").serialize;
+const blocks = @import("../blocks.zig");
+const t = @import("../testing.zig");
+
+/// Specifies all types that can be serialized by this block.
+pub fn is(
+    /// The type of a value being serialized.
+    comptime T: type,
+) bool {
+    const is_indexed_set = comptime std.mem.startsWith(u8, @typeName(T), "enums.IndexedSet");
+    const is_enum_set = comptime std.mem.startsWith(u8, @typeName(T), "enums.EnumSet");
+
+    return is_indexed_set or is_enum_set;
+}
+
+/// Specifies the serialization process for values relevant to this block.
+pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
+    /// A value being serialized.
+    value: anytype,
+    /// A `getty.Serializer` interface value.
+    serializer: anytype,
+) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+    return try getty_serialize(allocator, value.bits, serializer);
+}
+
+fn StringIndexer(comptime str_keys: []const []const u8) type {
+    if (str_keys.len == 0) {
+        return struct {
+            pub const Key = []const u8;
+            pub const count: usize = 0;
+            pub fn indexOf(k: Key) usize {
+                _ = k;
+                unreachable;
+            }
+            pub fn keyForIndex(i: usize) Key {
+                _ = i;
+                unreachable;
+            }
+        };
+    }
+
+    return struct {
+        pub const Key = []const u8;
+        pub const count: usize = str_keys.len;
+        pub fn indexOf(k: Key) usize {
+            for (str_keys, 0..) |key, i| {
+                if (std.mem.eql(u8, k, key)) {
+                    return i;
+                }
+            }
+            unreachable;
+        }
+        pub fn keyForIndex(i: usize) Key {
+            return str_keys[i];
+        }
+    };
+}
+
+test "serialize - std.IndexedSet" {
+    const Color = StringIndexer(&.{ "red", "yellow", "blue", "green", "orange", "violet", "indigo", "magenta" });
+
+    // Zero-sized
+    {
+        var want = std.enums.IndexedSet(StringIndexer(&.{}), null).initEmpty();
+
+        try t.run(null, serialize, want, &.{
+            .{ .Seq = .{ .len = 0 } },
+            .{ .SeqEnd = {} },
+        });
+    }
+
+    // Empty
+    {
+        var want = std.enums.IndexedSet(Color, null).initEmpty();
+
+        try t.run(null, serialize, want, &.{
+            .{ .Seq = .{ .len = 8 } },
+            .{ .U8 = 0 },
+            .{ .U8 = 0 },
+            .{ .U8 = 0 },
+            .{ .U8 = 0 },
+            .{ .U8 = 0 },
+            .{ .U8 = 0 },
+            .{ .U8 = 0 },
+            .{ .U8 = 0 },
+            .{ .SeqEnd = {} },
+        });
+    }
+
+    // Full
+    {
+        var want = std.enums.IndexedSet(Color, null).initFull();
+
+        try t.run(null, serialize, want, &.{
+            .{ .Seq = .{ .len = 8 } },
+            .{ .U8 = 1 },
+            .{ .U8 = 1 },
+            .{ .U8 = 1 },
+            .{ .U8 = 1 },
+            .{ .U8 = 1 },
+            .{ .U8 = 1 },
+            .{ .U8 = 1 },
+            .{ .U8 = 1 },
+            .{ .SeqEnd = {} },
+        });
+    }
+
+    // Mixed
+    {
+        var want = std.enums.IndexedSet(Color, null).initMany(&.{ "yellow", "green", "violet", "magenta" });
+
+        try t.run(null, serialize, want, &.{
+            .{ .Seq = .{ .len = 8 } },
+            .{ .U8 = 1 },
+            .{ .U8 = 0 },
+            .{ .U8 = 1 },
+            .{ .U8 = 0 },
+            .{ .U8 = 1 },
+            .{ .U8 = 0 },
+            .{ .U8 = 1 },
+            .{ .U8 = 0 },
+            .{ .SeqEnd = {} },
+        });
+    }
+}
+
+test "serialize - std.EnumSet" {
+    const Color = enum { red, yellow, blue, green, orange, violet, indigo, magenta };
+
+    // Zero-sized
+    // std.EnumIndexer, which is used internally by std.EnumSet,
+    // fails to compile on an empty enum due to field access occuring
+    // before checking field length.
+    // {
+    //     var want = std.enums.EnumSet(enum {}).initEmpty();
+
+    //     try t.run(null, serialize, want, &.{
+    //         .{ .Seq = .{ .len = 0 } },
+    //         .{ .SeqEnd = {} },
+    //     });
+    // }
+
+    // Empty
+    {
+        var want = std.enums.EnumSet(Color).initEmpty();
+
+        try t.run(null, serialize, want, &.{
+            .{ .Seq = .{ .len = 8 } },
+            .{ .U8 = 0 },
+            .{ .U8 = 0 },
+            .{ .U8 = 0 },
+            .{ .U8 = 0 },
+            .{ .U8 = 0 },
+            .{ .U8 = 0 },
+            .{ .U8 = 0 },
+            .{ .U8 = 0 },
+            .{ .SeqEnd = {} },
+        });
+    }
+
+    // Full
+    {
+        var want = std.enums.EnumSet(Color).initFull();
+
+        try t.run(null, serialize, want, &.{
+            .{ .Seq = .{ .len = 8 } },
+            .{ .U8 = 1 },
+            .{ .U8 = 1 },
+            .{ .U8 = 1 },
+            .{ .U8 = 1 },
+            .{ .U8 = 1 },
+            .{ .U8 = 1 },
+            .{ .U8 = 1 },
+            .{ .U8 = 1 },
+            .{ .SeqEnd = {} },
+        });
+    }
+
+    // Mixed
+    {
+        var want = std.enums.EnumSet(Color).init(.{ .yellow = true, .green = true, .violet = true, .magenta = true });
+
+        try t.run(null, serialize, want, &.{
+            .{ .Seq = .{ .len = 8 } },
+            .{ .U8 = 1 },
+            .{ .U8 = 0 },
+            .{ .U8 = 1 },
+            .{ .U8 = 0 },
+            .{ .U8 = 1 },
+            .{ .U8 = 0 },
+            .{ .U8 = 1 },
+            .{ .U8 = 0 },
+            .{ .SeqEnd = {} },
+        });
+    }
+}

--- a/src/ser/blocks/linear_fifo.zig
+++ b/src/ser/blocks/linear_fifo.zig
@@ -1,0 +1,110 @@
+const std = @import("std");
+
+const t = @import("../testing.zig");
+
+/// Specifies all types that can be serialized by this block.
+pub fn is(
+    /// The type of a value being serialized.
+    comptime T: type,
+) bool {
+    return comptime std.mem.startsWith(u8, @typeName(T), "fifo.LinearFifo");
+}
+
+/// Specifies the serialization process for values relevant to this block.
+pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
+    /// A value being serialized.
+    value: anytype,
+    /// A `getty.Serializer` interface value.
+    serializer: anytype,
+) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+    _ = allocator;
+
+    var s = try serializer.serializeSeq(value.readableLength());
+    const seq = s.seq();
+    for (0..value.readableLength()) |i| {
+        try seq.serializeElement(value.peekItem(i));
+    }
+    return try seq.end();
+}
+
+test "serialize - std.LinearFifo (static)" {
+    var fifo = std.fifo.LinearFifo(u8, .{ .Static = 8 }).init();
+
+    try t.run(null, serialize, fifo, &.{
+        .{ .Seq = .{ .len = 0 } },
+        .{ .SeqEnd = {} },
+    });
+
+    fifo.writeAssumeCapacity(&[_]u8{ 8, 7, 6, 5, 1, 2, 3, 4 });
+    fifo.discard(4);
+    fifo.writeAssumeCapacity(&[_]u8{ 8, 7, 6, 5 });
+
+    try t.run(null, serialize, fifo, &.{
+        .{ .Seq = .{ .len = 8 } },
+        .{ .U8 = 1 },
+        .{ .U8 = 2 },
+        .{ .U8 = 3 },
+        .{ .U8 = 4 },
+        .{ .U8 = 8 },
+        .{ .U8 = 7 },
+        .{ .U8 = 6 },
+        .{ .U8 = 5 },
+        .{ .SeqEnd = {} },
+    });
+}
+
+test "serialize - std.LinearFifo (slice)" {
+    var buf: [10]u8 = undefined;
+    var fifo = std.fifo.LinearFifo(u8, .Slice).init(&buf);
+
+    try t.run(null, serialize, fifo, &.{
+        .{ .Seq = .{ .len = 0 } },
+        .{ .SeqEnd = {} },
+    });
+
+    fifo.writeAssumeCapacity(&[_]u8{ 8, 7, 6, 5, 1, 2, 3, 4 });
+    fifo.discard(4);
+    fifo.writeAssumeCapacity(&[_]u8{ 8, 7, 6, 5 });
+
+    try t.run(null, serialize, fifo, &.{
+        .{ .Seq = .{ .len = 8 } },
+        .{ .U8 = 1 },
+        .{ .U8 = 2 },
+        .{ .U8 = 3 },
+        .{ .U8 = 4 },
+        .{ .U8 = 8 },
+        .{ .U8 = 7 },
+        .{ .U8 = 6 },
+        .{ .U8 = 5 },
+        .{ .SeqEnd = {} },
+    });
+}
+
+test "serialize - std.LinearFifo (dynamic)" {
+    var fifo = std.fifo.LinearFifo(u8, .Dynamic).init(std.testing.allocator);
+    defer fifo.deinit();
+
+    try t.run(null, serialize, fifo, &.{
+        .{ .Seq = .{ .len = 0 } },
+        .{ .SeqEnd = {} },
+    });
+
+    try fifo.write(&[_]u8{ 8, 7, 6, 5, 1, 2, 3, 4 });
+    fifo.discard(4);
+    try fifo.write(&[_]u8{ 8, 7, 6, 5 });
+
+    try t.run(null, serialize, fifo, &.{
+        .{ .Seq = .{ .len = 8 } },
+        .{ .U8 = 1 },
+        .{ .U8 = 2 },
+        .{ .U8 = 3 },
+        .{ .U8 = 4 },
+        .{ .U8 = 8 },
+        .{ .U8 = 7 },
+        .{ .U8 = 6 },
+        .{ .U8 = 5 },
+        .{ .SeqEnd = {} },
+    });
+}

--- a/src/ser/blocks/priority_dequeue.zig
+++ b/src/ser/blocks/priority_dequeue.zig
@@ -1,0 +1,64 @@
+const std = @import("std");
+
+const t = @import("../testing.zig");
+
+/// Specifies all types that can be serialized by this block.
+pub fn is(
+    /// The type of a value being serialized.
+    comptime T: type,
+) bool {
+    return comptime std.mem.startsWith(u8, @typeName(T), "priority_dequeue.PriorityDequeue");
+}
+
+/// Specifies the serialization process for values relevant to this block.
+pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
+    /// A value being serialized.
+    value: anytype,
+    /// A `getty.Serializer` interface value.
+    serializer: anytype,
+) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+    _ = allocator;
+
+    var s = try serializer.serializeSeq(value.count());
+    const seq = s.seq();
+    var mut = value;
+    var it = mut.iterator();
+    while (it.next()) |elem| {
+        try seq.serializeElement(elem);
+    }
+    return try seq.end();
+}
+
+fn lessThan(context: void, a: i32, b: i32) std.math.Order {
+    _ = context;
+    return std.math.order(a, b);
+}
+
+test "serialize - std.PriorityDequeue" {
+    var deque = std.PriorityDequeue(i32, void, lessThan).init(std.testing.allocator, {});
+    defer deque.deinit();
+
+    try t.run(null, serialize, deque, &.{
+        .{ .Seq = .{ .len = 0 } },
+        .{ .SeqEnd = {} },
+    });
+
+    try deque.add(1);
+    try deque.add(2);
+    try deque.add(3);
+
+    try deque.addSlice(&.{ -1, -2, -3 });
+
+    try t.run(null, serialize, deque, &.{
+        .{ .Seq = .{ .len = 6 } },
+        .{ .I32 = -3 },
+        .{ .I32 = 2 },
+        .{ .I32 = 3 },
+        .{ .I32 = 1 },
+        .{ .I32 = -1 },
+        .{ .I32 = -2 },
+        .{ .SeqEnd = {} },
+    });
+}

--- a/src/ser/blocks/priority_queue.zig
+++ b/src/ser/blocks/priority_queue.zig
@@ -1,0 +1,64 @@
+const std = @import("std");
+
+const t = @import("../testing.zig");
+
+/// Specifies all types that can be serialized by this block.
+pub fn is(
+    /// The type of a value being serialized.
+    comptime T: type,
+) bool {
+    return comptime std.mem.startsWith(u8, @typeName(T), "priority_queue.PriorityQueue");
+}
+
+/// Specifies the serialization process for values relevant to this block.
+pub fn serialize(
+    /// An optional memory allocator.
+    allocator: ?std.mem.Allocator,
+    /// A value being serialized.
+    value: anytype,
+    /// A `getty.Serializer` interface value.
+    serializer: anytype,
+) @TypeOf(serializer).Error!@TypeOf(serializer).Ok {
+    _ = allocator;
+
+    var s = try serializer.serializeSeq(value.count());
+    const seq = s.seq();
+    var mut = value;
+    var it = mut.iterator();
+    while (it.next()) |elem| {
+        try seq.serializeElement(elem);
+    }
+    return try seq.end();
+}
+
+fn lessThan(context: void, a: i32, b: i32) std.math.Order {
+    _ = context;
+    return std.math.order(a, b);
+}
+
+test "serialize - std.PriorityQueue" {
+    var queue = std.PriorityQueue(i32, void, lessThan).init(std.testing.allocator, {});
+    defer queue.deinit();
+
+    try t.run(null, serialize, queue, &.{
+        .{ .Seq = .{ .len = 0 } },
+        .{ .SeqEnd = {} },
+    });
+
+    try queue.add(1);
+    try queue.add(2);
+    try queue.add(3);
+
+    try queue.addSlice(&.{ -1, -2, -3 });
+
+    try t.run(null, serialize, queue, &.{
+        .{ .Seq = .{ .len = 6 } },
+        .{ .I32 = -3 },
+        .{ .I32 = -1 },
+        .{ .I32 = -2 },
+        .{ .I32 = 2 },
+        .{ .I32 = 1 },
+        .{ .I32 = 3 },
+        .{ .SeqEnd = {} },
+    });
+}

--- a/src/ser/tuples.zig
+++ b/src/ser/tuples.zig
@@ -106,6 +106,7 @@ pub const st = .{
     blocks.SinglyLinkedList,
     blocks.SemanticVersion,
     blocks.TailQueue,
+    blocks.LinearFifo,
     blocks.SegmentedList,
 
     ////////////////////////////////////////////////////////////////////////////

--- a/src/ser/tuples.zig
+++ b/src/ser/tuples.zig
@@ -69,6 +69,12 @@ pub const st = .{
 
     // Covers the following types:
     //
+    //   - std.EnumMultiset
+    //   - std.BoundedEnumMultiset
+    blocks.BoundedEnumMultiset,
+
+    // Covers the following types:
+    //
     //   - std.HashMap
     //   - std.HashMapUnmanaged
     //   - std.AutoHashMap

--- a/src/ser/tuples.zig
+++ b/src/ser/tuples.zig
@@ -77,6 +77,7 @@ pub const st = .{
     //   - std.PackedIntSliceEndian
     blocks.PackedIntArray,
 
+    blocks.PriorityQueue,
     blocks.SinglyLinkedList,
     blocks.SemanticVersion,
     blocks.TailQueue,

--- a/src/ser/tuples.zig
+++ b/src/ser/tuples.zig
@@ -51,6 +51,18 @@ pub const st = .{
 
     // Covers the following types:
     //
+    //   - std.EnumArray
+    //   - std.IndexedArray
+    blocks.IndexedArray,
+
+    // Covers the following types:
+    //
+    //   - std.EnumMultiset
+    //   - std.BoundedEnumMultiset
+    blocks.BoundedEnumMultiset,
+
+    // Covers the following types:
+    //
     //   - std.HashMap
     //   - std.HashMapUnmanaged
     //   - std.AutoHashMap

--- a/src/ser/tuples.zig
+++ b/src/ser/tuples.zig
@@ -57,6 +57,12 @@ pub const st = .{
 
     // Covers the following types:
     //
+    //   - std.EnumSet
+    //   - std.IndexedSet
+    blocks.IndexedSet,
+
+    // Covers the following types:
+    //
     //   - std.EnumMap
     //   - std.IndexedMap
     blocks.IndexedMap,

--- a/src/ser/tuples.zig
+++ b/src/ser/tuples.zig
@@ -57,9 +57,9 @@ pub const st = .{
 
     // Covers the following types:
     //
-    //   - std.EnumMultiset
-    //   - std.BoundedEnumMultiset
-    blocks.BoundedEnumMultiset,
+    //   - std.EnumMap
+    //   - std.IndexedMap
+    blocks.IndexedMap,
 
     // Covers the following types:
     //

--- a/src/ser/tuples.zig
+++ b/src/ser/tuples.zig
@@ -78,6 +78,7 @@ pub const st = .{
     blocks.PackedIntArray,
 
     blocks.PriorityQueue,
+    blocks.PriorityDequeue,
     blocks.SinglyLinkedList,
     blocks.SemanticVersion,
     blocks.TailQueue,


### PR DESCRIPTION
Context: https://github.com/getty-zig/getty/issues/120

Added (de)serialization support for the following standard library types:
- [x] PriorityQueue
- [x] PriorityDequeue
- [x] BoundedEnumMultiset/EnumMultiset
- [x] IndexedArray
- [x] IndexedMap
- [x] IndexedSet
- [x] LinearFifo

cc: @ibokuri for review