### PR TITLE
de: Add allocation check functions to aggregate access interfaces

### DIFF
--- a/src/de/interfaces/map_access.zig
+++ b/src/de/interfaces/map_access.zig
@@ -41,6 +41,10 @@ pub fn MapAccess(
         /// Returns true if the latest key deserialized by nextKeySeed was
         /// allocated on the heap. Otherwise, false is returned.
         isKeyAllocated: ?fn (Context, comptime K: type) bool = null,
+
+        /// Returns true if the latest value deserialized by nextValueSeed was
+        /// allocated on the heap. Otherwise, false is returned.
+        isValueAllocated: ?fn (Context, comptime V: type) bool = null,
     },
 ) type {
     return struct {
@@ -104,6 +108,14 @@ pub fn MapAccess(
                 }
 
                 return @typeInfo(K) == .Pointer;
+            }
+
+            pub fn isValueAllocated(self: Self, comptime V: type) bool {
+                if (methods.isValueAllocated) |f| {
+                    return f(self.context, V);
+                }
+
+                return @typeInfo(V) == .Pointer;
             }
         };
 

--- a/src/de/interfaces/seq_access.zig
+++ b/src/de/interfaces/seq_access.zig
@@ -22,6 +22,10 @@ pub fn SeqAccess(
                 unreachable;
             }
         }.f) = null,
+
+        /// Returns true if the latest value deserialized by nextElementSeed was
+        /// allocated on the heap. Otherwise, false is returned.
+        isElementAllocated: ?fn (Context, comptime T: type) bool = null,
     },
 ) type {
     return struct {
@@ -50,6 +54,14 @@ pub fn SeqAccess(
 
                     return try self.nextElementSeed(ally, ds);
                 }
+            }
+
+            pub fn isElementAllocated(self: Self, comptime T: type) bool {
+                if (methods.isElementAllocated) |f| {
+                    return f(self.context, T);
+                }
+
+                return @typeInfo(T) == .Pointer;
             }
         };
 

--- a/src/de/interfaces/variant_access.zig
+++ b/src/de/interfaces/variant_access.zig
@@ -22,6 +22,10 @@ pub fn VariantAccess(
                 unreachable;
             }
         }.f) = null,
+
+        /// Returns true if the latest value deserialized by payloadSeed was
+        /// allocated on the heap. Otherwise, false is returned.
+        isPayloadAllocated: ?fn (Context, comptime T: type) bool = null,
     },
 ) type {
     return struct {
@@ -50,6 +54,14 @@ pub fn VariantAccess(
 
                     return try self.payloadSeed(ally, seed);
                 }
+            }
+
+            pub fn isPayloadAllocated(self: Self, comptime T: type) bool {
+                if (methods.isPayloadAllocated) |f| {
+                    return f(self.context, T);
+                }
+
+                return @typeInfo(T) == .Pointer;
             }
         };
 


### PR DESCRIPTION
This commit implements proposal https://github.com/getty-zig/getty/issues/127 to adds allocation check functions
for aggregate access interfaces, namingly the functions `isElementAllocated`,
`isValueAllocated`, `isPayloadAllocated` to the SeqAccess, MapAccess and
VariantAccess interfaces respectively. This allows checking the storage
location of a value deserialized from access methods (e.g., `nextKey`) and
makes it possible to conditionally free the value only if it is allocated on
the heap. Thus, eliminating the need to unconditionally free values which
in some cases force an allocator to be passed for deserialization even if
no allocation would take place, contravening the principle of least privilege.

closes https://github.com/getty-zig/getty/issues/127