### PR TITLE
de: Better autodocs for interface methods

### DIFF
--- a/src/de/interfaces/deserializer.zig
+++ b/src/de/interfaces/deserializer.zig
@@ -261,7 +261,10 @@ pub fn Deserializer(
 
 fn DeserializeFn(comptime Impl: type, comptime Err: type) type {
     const Lambda = struct {
-        fn func(_: Impl, _: ?std.mem.Allocator, visitor: anytype) Err!@TypeOf(visitor).Value {
+        fn func(impl: Impl, ally: ?std.mem.Allocator, visitor: anytype) Err!@TypeOf(visitor).Value {
+            _ = impl;
+            _ = ally;
+
             unreachable;
         }
     };

--- a/src/de/interfaces/deserializer.zig
+++ b/src/de/interfaces/deserializer.zig
@@ -7,33 +7,27 @@ const err = @import("../error.zig");
 pub fn Deserializer(
     /// An implementing type.
     comptime Impl: type,
-    /// The error set returned by the interface's methods upon failure.
-    comptime E: type,
+    /// The error set to be returned by the interface's methods upon failure.
+    comptime Err: type,
     /// An optional, user-defined deserialization block or tuple.
     comptime user_dbt: anytype,
     /// An optional, deserializer-defined deserialization block or tuple.
     comptime deserializer_dbt: anytype,
     /// A namespace containing methods that `Impl` must define or can override.
     comptime methods: struct {
-        const T = ?@TypeOf(struct {
-            fn f(_: Impl, _: ?std.mem.Allocator, visitor: anytype) E!@TypeOf(visitor).Value {
-                unreachable;
-            }
-        }.f);
-
-        deserializeAny: T = null,
-        deserializeBool: T = null,
-        deserializeEnum: T = null,
-        deserializeFloat: T = null,
-        deserializeIgnored: T = null,
-        deserializeInt: T = null,
-        deserializeMap: T = null,
-        deserializeOptional: T = null,
-        deserializeSeq: T = null,
-        deserializeString: T = null,
-        deserializeStruct: T = null,
-        deserializeUnion: T = null,
-        deserializeVoid: T = null,
+        deserializeAny: DeserializeFn(Impl, Err) = null,
+        deserializeBool: DeserializeFn(Impl, Err) = null,
+        deserializeEnum: DeserializeFn(Impl, Err) = null,
+        deserializeFloat: DeserializeFn(Impl, Err) = null,
+        deserializeIgnored: DeserializeFn(Impl, Err) = null,
+        deserializeInt: DeserializeFn(Impl, Err) = null,
+        deserializeMap: DeserializeFn(Impl, Err) = null,
+        deserializeOptional: DeserializeFn(Impl, Err) = null,
+        deserializeSeq: DeserializeFn(Impl, Err) = null,
+        deserializeString: DeserializeFn(Impl, Err) = null,
+        deserializeStruct: DeserializeFn(Impl, Err) = null,
+        deserializeUnion: DeserializeFn(Impl, Err) = null,
+        deserializeVoid: DeserializeFn(Impl, Err) = null,
     },
 ) type {
     return struct {
@@ -45,11 +39,11 @@ pub fn Deserializer(
 
             /// Error set used upon failure.
             pub const Error = blk: {
-                if (E != E || err.Error) {
+                if (Err != Err || err.Error) {
                     @compileError("error set must include `getty.de.Error`");
                 }
 
-                break :blk E;
+                break :blk Err;
             };
 
             /// User-defined Deserialization Tuple.
@@ -139,36 +133,36 @@ pub fn Deserializer(
             };
 
             /// Deserializes a deserializer's input data into some Getty value.
-            pub fn deserializeAny(self: Self, ally: ?std.mem.Allocator, visitor: anytype) Error!@TypeOf(visitor).Value {
-                if (methods.deserializeAny) |f| {
-                    return try f(self.impl, ally, visitor);
+            pub fn deserializeAny(self: Self, ally: ?std.mem.Allocator, visitor: anytype) Err!@TypeOf(visitor).Value {
+                if (methods.deserializeAny) |func| {
+                    return try func(self.impl, ally, visitor);
                 }
 
                 @compileError("deserializeAny is not implemented by type: " ++ @typeName(Impl));
             }
 
             /// Deserializes a deserializer's input data into a Getty Boolean.
-            pub fn deserializeBool(self: Self, ally: ?std.mem.Allocator, visitor: anytype) Error!@TypeOf(visitor).Value {
-                if (methods.deserializeBool) |f| {
-                    return try f(self.impl, ally, visitor);
+            pub fn deserializeBool(self: Self, ally: ?std.mem.Allocator, visitor: anytype) Err!@TypeOf(visitor).Value {
+                if (methods.deserializeBool) |func| {
+                    return try func(self.impl, ally, visitor);
                 }
 
                 @compileError("deserializeBool is not implemented by type: " ++ @typeName(Impl));
             }
 
             /// Deserializes a deserializer's input data into a Getty Enum.
-            pub fn deserializeEnum(self: Self, ally: ?std.mem.Allocator, visitor: anytype) Error!@TypeOf(visitor).Value {
-                if (methods.deserializeEnum) |f| {
-                    return try f(self.impl, ally, visitor);
+            pub fn deserializeEnum(self: Self, ally: ?std.mem.Allocator, visitor: anytype) Err!@TypeOf(visitor).Value {
+                if (methods.deserializeEnum) |func| {
+                    return try func(self.impl, ally, visitor);
                 }
 
                 @compileError("deserializeEnum is not implemented by type: " ++ @typeName(Impl));
             }
 
             /// Deserializes a deserializer's input data into a Getty Float.
-            pub fn deserializeFloat(self: Self, ally: ?std.mem.Allocator, visitor: anytype) Error!@TypeOf(visitor).Value {
-                if (methods.deserializeFloat) |f| {
-                    return try f(self.impl, ally, visitor);
+            pub fn deserializeFloat(self: Self, ally: ?std.mem.Allocator, visitor: anytype) Err!@TypeOf(visitor).Value {
+                if (methods.deserializeFloat) |func| {
+                    return try func(self.impl, ally, visitor);
                 }
 
                 @compileError("deserializeFloat is not implemented by type: " ++ @typeName(Impl));
@@ -177,81 +171,81 @@ pub fn Deserializer(
             /// Hint that the type being deserialized into is expecting to
             /// deserialize a value whose type does not matter because it is
             /// ignored.
-            pub fn deserializeIgnored(self: Self, ally: ?std.mem.Allocator, visitor: anytype) Error!@TypeOf(visitor).Value {
-                if (methods.deserializeIgnored) |f| {
-                    return try f(self.impl, ally, visitor);
+            pub fn deserializeIgnored(self: Self, ally: ?std.mem.Allocator, visitor: anytype) Err!@TypeOf(visitor).Value {
+                if (methods.deserializeIgnored) |func| {
+                    return try func(self.impl, ally, visitor);
                 }
 
                 @compileError("deserializeIgnored is not implemented by type: " ++ @typeName(Impl));
             }
 
             /// Deserializes a deserializer's input data into a Getty Integer.
-            pub fn deserializeInt(self: Self, ally: ?std.mem.Allocator, visitor: anytype) Error!@TypeOf(visitor).Value {
-                if (methods.deserializeInt) |f| {
-                    return try f(self.impl, ally, visitor);
+            pub fn deserializeInt(self: Self, ally: ?std.mem.Allocator, visitor: anytype) Err!@TypeOf(visitor).Value {
+                if (methods.deserializeInt) |func| {
+                    return try func(self.impl, ally, visitor);
                 }
 
                 @compileError("deserializeInt is not implemented by type: " ++ @typeName(Impl));
             }
 
             /// Deserializes a deserializer's input data into a Getty Map.
-            pub fn deserializeMap(self: Self, ally: ?std.mem.Allocator, visitor: anytype) Error!@TypeOf(visitor).Value {
-                if (methods.deserializeMap) |f| {
-                    return try f(self.impl, ally, visitor);
+            pub fn deserializeMap(self: Self, ally: ?std.mem.Allocator, visitor: anytype) Err!@TypeOf(visitor).Value {
+                if (methods.deserializeMap) |func| {
+                    return try func(self.impl, ally, visitor);
                 }
 
                 @compileError("deserializeMap is not implemented by type: " ++ @typeName(Impl));
             }
 
             /// Deserializes a deserializer's input data into a Getty Optional.
-            pub fn deserializeOptional(self: Self, ally: ?std.mem.Allocator, visitor: anytype) Error!@TypeOf(visitor).Value {
-                if (methods.deserializeOptional) |f| {
-                    return try f(self.impl, ally, visitor);
+            pub fn deserializeOptional(self: Self, ally: ?std.mem.Allocator, visitor: anytype) Err!@TypeOf(visitor).Value {
+                if (methods.deserializeOptional) |func| {
+                    return try func(self.impl, ally, visitor);
                 }
 
                 @compileError("deserializeOptional is not implemented by type: " ++ @typeName(Impl));
             }
 
             /// Deserializes a deserializer's input data into a Getty Sequence.
-            pub fn deserializeSeq(self: Self, ally: ?std.mem.Allocator, visitor: anytype) Error!@TypeOf(visitor).Value {
-                if (methods.deserializeSeq) |f| {
-                    return try f(self.impl, ally, visitor);
+            pub fn deserializeSeq(self: Self, ally: ?std.mem.Allocator, visitor: anytype) Err!@TypeOf(visitor).Value {
+                if (methods.deserializeSeq) |func| {
+                    return try func(self.impl, ally, visitor);
                 }
 
                 @compileError("deserializeSeq is not implemented by type: " ++ @typeName(Impl));
             }
 
             /// Deserializes a deserializer's input data into a Getty String.
-            pub fn deserializeString(self: Self, ally: ?std.mem.Allocator, visitor: anytype) Error!@TypeOf(visitor).Value {
-                if (methods.deserializeString) |f| {
-                    return try f(self.impl, ally, visitor);
+            pub fn deserializeString(self: Self, ally: ?std.mem.Allocator, visitor: anytype) Err!@TypeOf(visitor).Value {
+                if (methods.deserializeString) |func| {
+                    return try func(self.impl, ally, visitor);
                 }
 
                 @compileError("deserializeString is not implemented by type: " ++ @typeName(Impl));
             }
 
             /// Deserializes a deserializer's input data into a Getty Struct.
-            pub fn deserializeStruct(self: Self, ally: ?std.mem.Allocator, visitor: anytype) Error!@TypeOf(visitor).Value {
-                if (methods.deserializeStruct) |f| {
-                    return try f(self.impl, ally, visitor);
+            pub fn deserializeStruct(self: Self, ally: ?std.mem.Allocator, visitor: anytype) Err!@TypeOf(visitor).Value {
+                if (methods.deserializeStruct) |func| {
+                    return try func(self.impl, ally, visitor);
                 }
 
                 @compileError("deserializeStruct is not implemented by type: " ++ @typeName(Impl));
             }
 
             /// Deserializes a deserializer's input data into a Getty Union.
-            pub fn deserializeUnion(self: Self, ally: ?std.mem.Allocator, visitor: anytype) Error!@TypeOf(visitor).Value {
-                if (methods.deserializeUnion) |f| {
-                    return try f(self.impl, ally, visitor);
+            pub fn deserializeUnion(self: Self, ally: ?std.mem.Allocator, visitor: anytype) Err!@TypeOf(visitor).Value {
+                if (methods.deserializeUnion) |func| {
+                    return try func(self.impl, ally, visitor);
                 }
 
                 @compileError("deserializeUnion is not implemented by type: " ++ @typeName(Impl));
             }
 
             /// Deserializes a deserializer's input data into a Getty Void.
-            pub fn deserializeVoid(self: Self, ally: ?std.mem.Allocator, visitor: anytype) Error!@TypeOf(visitor).Value {
-                if (methods.deserializeVoid) |f| {
-                    return try f(self.impl, ally, visitor);
+            pub fn deserializeVoid(self: Self, ally: ?std.mem.Allocator, visitor: anytype) Err!@TypeOf(visitor).Value {
+                if (methods.deserializeVoid) |func| {
+                    return try func(self.impl, ally, visitor);
                 }
 
                 @compileError("deserializeVoid is not implemented by type: " ++ @typeName(Impl));
@@ -263,4 +257,14 @@ pub fn Deserializer(
             return .{ .impl = impl };
         }
     };
+}
+
+fn DeserializeFn(comptime Impl: type, comptime Err: type) type {
+    const Lambda = struct {
+        fn func(_: Impl, _: ?std.mem.Allocator, visitor: anytype) Err!@TypeOf(visitor).Value {
+            unreachable;
+        }
+    };
+
+    return ?@TypeOf(Lambda.func);
 }

--- a/src/de/interfaces/map_access.zig
+++ b/src/de/interfaces/map_access.zig
@@ -10,8 +10,8 @@ pub fn MapAccess(
     comptime Err: type,
     /// A namespace containing methods that `Impl` must define or can override.
     comptime methods: struct {
-        nextKeySeed: ?NextKeySeedFn(Impl, Err) = null,
-        nextValueSeed: ?NextValueSeedFn(Impl, Err) = null,
+        nextKeySeed: NextKeySeedFn(Impl, Err) = null,
+        nextValueSeed: NextValueSeedFn(Impl, Err) = null,
         nextKey: ?NextKeyFn(Impl, Err) = null,
         nextValue: ?NextValueFn(Impl, Err) = null,
         isKeyAllocated: ?IsAllocatedFn(Impl) = null,
@@ -96,26 +96,22 @@ fn NextKeySeedFn(comptime Impl: type, comptime Err: type) type {
         }
     };
 
-    return @TypeOf(Lambda.func);
-}
-
-fn NextKeyFn(comptime Impl: type, comptime Err: type) type {
-    const Lambda = struct {
-        fn func(_: Impl, _: ?std.mem.Allocator, comptime Key: type) Err!?Key {
-            unreachable;
-        }
-    };
-
-    return @TypeOf(Lambda.func);
-}
-
-fn IsAllocatedFn(comptime Impl: type) type {
-    return fn (Impl, comptime KV: type) bool;
+    return ?@TypeOf(Lambda.func);
 }
 
 fn NextValueSeedFn(comptime Impl: type, comptime Err: type) type {
     const Lambda = struct {
         fn func(_: Impl, _: ?std.mem.Allocator, seed: anytype) Err!@TypeOf(seed).Value {
+            unreachable;
+        }
+    };
+
+    return ?@TypeOf(Lambda.func);
+}
+
+fn NextKeyFn(comptime Impl: type, comptime Err: type) type {
+    const Lambda = struct {
+        fn func(_: Impl, _: ?std.mem.Allocator, comptime Key: type) Err!?Key {
             unreachable;
         }
     };
@@ -131,4 +127,8 @@ fn NextValueFn(comptime Impl: type, comptime Err: type) type {
     };
 
     return @TypeOf(Lambda.func);
+}
+
+fn IsAllocatedFn(comptime Impl: type) type {
+    return fn (Impl, comptime KV: type) bool;
 }

--- a/src/de/interfaces/map_access.zig
+++ b/src/de/interfaces/map_access.zig
@@ -27,7 +27,7 @@ pub fn MapAccess(
 
             pub const Error = Err;
 
-            pub fn nextKeySeed(self: Self, ally: ?std.mem.Allocator, seed: anytype) Error!?@TypeOf(seed).Value {
+            pub fn nextKeySeed(self: Self, ally: ?std.mem.Allocator, seed: anytype) Err!?@TypeOf(seed).Value {
                 if (methods.nextKeySeed) |func| {
                     return try func(self.impl, ally, seed);
                 }
@@ -35,7 +35,7 @@ pub fn MapAccess(
                 @compileError("nextKeySeed is not implemented by type: " ++ @typeName(Impl));
             }
 
-            pub fn nextValueSeed(self: Self, ally: ?std.mem.Allocator, seed: anytype) Error!@TypeOf(seed).Value {
+            pub fn nextValueSeed(self: Self, ally: ?std.mem.Allocator, seed: anytype) Err!@TypeOf(seed).Value {
                 if (methods.nextValueSeed) |func| {
                     return try func(self.impl, ally, seed);
                 }
@@ -43,7 +43,7 @@ pub fn MapAccess(
                 @compileError("nextValueSeed is not implemented by type: " ++ @typeName(Impl));
             }
 
-            pub fn nextKey(self: Self, ally: ?std.mem.Allocator, comptime Key: type) Error!?Key {
+            pub fn nextKey(self: Self, ally: ?std.mem.Allocator, comptime Key: type) Err!?Key {
                 if (methods.nextKey) |func| {
                     return try func(self.impl, ally, Key);
                 }
@@ -54,7 +54,7 @@ pub fn MapAccess(
                 return try self.nextKeySeed(ally, ds);
             }
 
-            pub fn nextValue(self: Self, ally: ?std.mem.Allocator, comptime Value: type) Error!Value {
+            pub fn nextValue(self: Self, ally: ?std.mem.Allocator, comptime Value: type) Err!Value {
                 if (methods.nextValue) |func| {
                     return try func(self.impl, ally, Value);
                 }

--- a/src/de/interfaces/map_access.zig
+++ b/src/de/interfaces/map_access.zig
@@ -91,7 +91,10 @@ pub fn MapAccess(
 
 fn NextKeySeedFn(comptime Impl: type, comptime Err: type) type {
     const Lambda = struct {
-        fn func(_: Impl, _: ?std.mem.Allocator, seed: anytype) Err!?@TypeOf(seed).Value {
+        fn func(impl: Impl, ally: ?std.mem.Allocator, seed: anytype) Err!?@TypeOf(seed).Value {
+            _ = impl;
+            _ = ally;
+
             unreachable;
         }
     };
@@ -101,7 +104,10 @@ fn NextKeySeedFn(comptime Impl: type, comptime Err: type) type {
 
 fn NextValueSeedFn(comptime Impl: type, comptime Err: type) type {
     const Lambda = struct {
-        fn func(_: Impl, _: ?std.mem.Allocator, seed: anytype) Err!@TypeOf(seed).Value {
+        fn func(impl: Impl, ally: ?std.mem.Allocator, seed: anytype) Err!@TypeOf(seed).Value {
+            _ = impl;
+            _ = ally;
+
             unreachable;
         }
     };
@@ -111,7 +117,10 @@ fn NextValueSeedFn(comptime Impl: type, comptime Err: type) type {
 
 fn NextKeyFn(comptime Impl: type, comptime Err: type) type {
     const Lambda = struct {
-        fn func(_: Impl, _: ?std.mem.Allocator, comptime Key: type) Err!?Key {
+        fn func(impl: Impl, ally: ?std.mem.Allocator, comptime Key: type) Err!?Key {
+            _ = impl;
+            _ = ally;
+
             unreachable;
         }
     };
@@ -121,7 +130,10 @@ fn NextKeyFn(comptime Impl: type, comptime Err: type) type {
 
 fn NextValueFn(comptime Impl: type, comptime Err: type) type {
     const Lambda = struct {
-        fn func(_: Impl, _: ?std.mem.Allocator, comptime Value: type) Err!Value {
+        fn func(impl: Impl, ally: ?std.mem.Allocator, comptime Value: type) Err!Value {
+            _ = impl;
+            _ = ally;
+
             unreachable;
         }
     };

--- a/src/de/interfaces/seed.zig
+++ b/src/de/interfaces/seed.zig
@@ -18,7 +18,7 @@ pub fn Seed(
     comptime V: type,
     /// A namespace containing methods that `Impl` must define or can override.
     comptime methods: struct {
-        deserialize: ?DeserializeFn(Impl, V) = null,
+        deserialize: DeserializeFn(Impl, V) = null,
     },
 ) type {
     return struct {
@@ -53,5 +53,5 @@ fn DeserializeFn(comptime Impl: type, comptime Value: type) type {
         }
     };
 
-    return @TypeOf(Lambda.func);
+    return ?@TypeOf(Lambda.func);
 }

--- a/src/de/interfaces/seed.zig
+++ b/src/de/interfaces/seed.zig
@@ -48,7 +48,10 @@ pub fn Seed(
 
 fn DeserializeFn(comptime Impl: type, comptime Value: type) type {
     const Lambda = struct {
-        fn func(_: Impl, _: ?std.mem.Allocator, deserializer: anytype) @TypeOf(deserializer).Error!Value {
+        fn func(impl: Impl, ally: ?std.mem.Allocator, deserializer: anytype) @TypeOf(deserializer).Error!Value {
+            _ = impl;
+            _ = ally;
+
             unreachable;
         }
     };

--- a/src/de/interfaces/seq_access.zig
+++ b/src/de/interfaces/seq_access.zig
@@ -24,7 +24,7 @@ pub fn SeqAccess(
 
             pub const Error = Err;
 
-            pub fn nextElementSeed(self: Self, ally: ?std.mem.Allocator, seed: anytype) Error!?@TypeOf(seed).Value {
+            pub fn nextElementSeed(self: Self, ally: ?std.mem.Allocator, seed: anytype) Err!?@TypeOf(seed).Value {
                 if (methods.nextElementSeed) |func| {
                     return try func(self.impl, ally, seed);
                 }
@@ -32,7 +32,7 @@ pub fn SeqAccess(
                 @compileError("nextElementSeed is not implemented by type: " ++ @typeName(Impl));
             }
 
-            pub fn nextElement(self: Self, ally: ?std.mem.Allocator, comptime Elem: type) Error!?Elem {
+            pub fn nextElement(self: Self, ally: ?std.mem.Allocator, comptime Elem: type) Err!?Elem {
                 if (methods.nextElement) |func| {
                     return try func(self.impl, ally, Elem);
                 }

--- a/src/de/interfaces/seq_access.zig
+++ b/src/de/interfaces/seq_access.zig
@@ -10,7 +10,7 @@ pub fn SeqAccess(
     comptime Err: type,
     /// A namespace containing methods that `Impl` must define or can override.
     comptime methods: struct {
-        nextElementSeed: ?NextElementSeedFn(Impl, Err) = null,
+        nextElementSeed: NextElementSeedFn(Impl, Err) = null,
         nextElement: ?NextElementFn(Impl, Err) = null,
         isElementAllocated: ?IsElementAllocatedFn(Impl) = null,
     },
@@ -66,7 +66,7 @@ fn NextElementSeedFn(comptime Impl: type, comptime Err: type) type {
         }
     };
 
-    return @TypeOf(Lambda.func);
+    return ?@TypeOf(Lambda.func);
 }
 
 fn NextElementFn(comptime Impl: type, comptime Err: type) type {

--- a/src/de/interfaces/seq_access.zig
+++ b/src/de/interfaces/seq_access.zig
@@ -61,7 +61,10 @@ pub fn SeqAccess(
 
 fn NextElementSeedFn(comptime Impl: type, comptime Err: type) type {
     const Lambda = struct {
-        fn func(_: Impl, _: ?std.mem.Allocator, seed: anytype) Err!?@TypeOf(seed).Value {
+        fn func(impl: Impl, ally: ?std.mem.Allocator, seed: anytype) Err!?@TypeOf(seed).Value {
+            _ = impl;
+            _ = ally;
+
             unreachable;
         }
     };
@@ -71,7 +74,10 @@ fn NextElementSeedFn(comptime Impl: type, comptime Err: type) type {
 
 fn NextElementFn(comptime Impl: type, comptime Err: type) type {
     const Lambda = struct {
-        fn func(_: Impl, _: ?std.mem.Allocator, comptime Elem: type) Err!?Elem {
+        fn func(impl: Impl, ally: ?std.mem.Allocator, comptime Elem: type) Err!?Elem {
+            _ = impl;
+            _ = ally;
+
             unreachable;
         }
     };

--- a/src/de/interfaces/seq_access.zig
+++ b/src/de/interfaces/seq_access.zig
@@ -6,26 +6,13 @@ const DefaultSeed = @import("../impls/seed/default.zig").DefaultSeed;
 pub fn SeqAccess(
     /// An implementing type.
     comptime Impl: type,
-    /// The error set returned by the interface's methods upon failure.
-    comptime E: type,
+    /// The error set to be returned by the interface's methods upon failure.
+    comptime Err: type,
     /// A namespace containing methods that `Impl` must define or can override.
     comptime methods: struct {
-        nextElementSeed: ?@TypeOf(struct {
-            fn f(_: Impl, _: ?std.mem.Allocator, seed: anytype) E!?@TypeOf(seed).Value {
-                unreachable;
-            }
-        }.f) = null,
-
-        // Provided method.
-        nextElement: ?@TypeOf(struct {
-            fn f(_: Impl, _: ?std.mem.Allocator, comptime Value: type) E!?Value {
-                unreachable;
-            }
-        }.f) = null,
-
-        /// Returns true if the latest value deserialized by nextElementSeed was
-        /// allocated on the heap. Otherwise, false is returned.
-        isElementAllocated: ?fn (Impl, comptime T: type) bool = null,
+        nextElementSeed: ?NextElementSeedFn(Impl, Err) = null,
+        nextElement: ?NextElementFn(Impl, Err) = null,
+        isElementAllocated: ?IsElementAllocatedFn(Impl) = null,
     },
 ) type {
     return struct {
@@ -35,33 +22,33 @@ pub fn SeqAccess(
 
             const Self = @This();
 
-            pub const Error = E;
+            pub const Error = Err;
 
             pub fn nextElementSeed(self: Self, ally: ?std.mem.Allocator, seed: anytype) Error!?@TypeOf(seed).Value {
-                if (methods.nextElementSeed) |f| {
-                    return try f(self.impl, ally, seed);
+                if (methods.nextElementSeed) |func| {
+                    return try func(self.impl, ally, seed);
                 }
 
                 @compileError("nextElementSeed is not implemented by type: " ++ @typeName(Impl));
             }
 
-            pub fn nextElement(self: Self, ally: ?std.mem.Allocator, comptime Value: type) Error!?Value {
-                if (methods.nextElement) |f| {
-                    return try f(self.impl, ally, Value);
-                } else {
-                    var seed = DefaultSeed(Value){};
-                    const ds = seed.seed();
-
-                    return try self.nextElementSeed(ally, ds);
+            pub fn nextElement(self: Self, ally: ?std.mem.Allocator, comptime Elem: type) Error!?Elem {
+                if (methods.nextElement) |func| {
+                    return try func(self.impl, ally, Elem);
                 }
+
+                var seed = DefaultSeed(Elem){};
+                const ds = seed.seed();
+
+                return try self.nextElementSeed(ally, ds);
             }
 
-            pub fn isElementAllocated(self: Self, comptime T: type) bool {
-                if (methods.isElementAllocated) |f| {
-                    return f(self.impl, T);
+            pub fn isElementAllocated(self: Self, comptime Elem: type) bool {
+                if (methods.isElementAllocated) |func| {
+                    return func(self.impl, Elem);
                 }
 
-                return @typeInfo(T) == .Pointer;
+                return @typeInfo(Elem) == .Pointer;
             }
         };
 
@@ -70,4 +57,28 @@ pub fn SeqAccess(
             return .{ .impl = impl };
         }
     };
+}
+
+fn NextElementSeedFn(comptime Impl: type, comptime Err: type) type {
+    const Lambda = struct {
+        fn func(_: Impl, _: ?std.mem.Allocator, seed: anytype) Err!?@TypeOf(seed).Value {
+            unreachable;
+        }
+    };
+
+    return @TypeOf(Lambda.func);
+}
+
+fn NextElementFn(comptime Impl: type, comptime Err: type) type {
+    const Lambda = struct {
+        fn func(_: Impl, _: ?std.mem.Allocator, comptime Elem: type) Err!?Elem {
+            unreachable;
+        }
+    };
+
+    return @TypeOf(Lambda.func);
+}
+
+fn IsElementAllocatedFn(comptime Impl: type) type {
+    return fn (Impl, comptime Elem: type) bool;
 }

--- a/src/de/interfaces/union_access.zig
+++ b/src/de/interfaces/union_access.zig
@@ -24,7 +24,7 @@ pub fn UnionAccess(
 
             pub const Error = Err;
 
-            pub fn variantSeed(self: Self, ally: ?std.mem.Allocator, seed: anytype) Error!@TypeOf(seed).Value {
+            pub fn variantSeed(self: Self, ally: ?std.mem.Allocator, seed: anytype) Err!@TypeOf(seed).Value {
                 if (methods.variantSeed) |func| {
                     return try func(self.impl, ally, seed);
                 }
@@ -32,7 +32,7 @@ pub fn UnionAccess(
                 @compileError("variantSeed is not implemented by type: " ++ @typeName(Impl));
             }
 
-            pub fn variant(self: Self, ally: ?std.mem.Allocator, comptime Variant: type) Error!Variant {
+            pub fn variant(self: Self, ally: ?std.mem.Allocator, comptime Variant: type) Err!Variant {
                 if (methods.variant) |func| {
                     return try func(self.impl, ally, Variant);
                 }

--- a/src/de/interfaces/union_access.zig
+++ b/src/de/interfaces/union_access.zig
@@ -10,7 +10,7 @@ pub fn UnionAccess(
     comptime Err: type,
     /// A namespace containing methods that `Impl` must define or can override.
     comptime methods: struct {
-        variantSeed: ?VariantSeedFn(Impl, Err) = null,
+        variantSeed: VariantSeedFn(Impl, Err) = null,
         variant: ?VariantFn(Impl, Err) = null,
         isVariantAllocated: ?IsVariantAllocatedFn(Impl) = null,
     },
@@ -66,7 +66,7 @@ fn VariantSeedFn(comptime Impl: type, comptime Err: type) type {
         }
     };
 
-    return @TypeOf(Lambda.func);
+    return ?@TypeOf(Lambda.func);
 }
 
 fn VariantFn(comptime Impl: type, comptime Err: type) type {

--- a/src/de/interfaces/union_access.zig
+++ b/src/de/interfaces/union_access.zig
@@ -61,7 +61,10 @@ pub fn UnionAccess(
 
 fn VariantSeedFn(comptime Impl: type, comptime Err: type) type {
     const Lambda = struct {
-        fn func(_: Impl, _: ?std.mem.Allocator, seed: anytype) Err!@TypeOf(seed).Value {
+        fn func(impl: Impl, ally: ?std.mem.Allocator, seed: anytype) Err!@TypeOf(seed).Value {
+            _ = impl;
+            _ = ally;
+
             unreachable;
         }
     };
@@ -71,7 +74,10 @@ fn VariantSeedFn(comptime Impl: type, comptime Err: type) type {
 
 fn VariantFn(comptime Impl: type, comptime Err: type) type {
     const Lambda = struct {
-        fn func(_: Impl, _: ?std.mem.Allocator, comptime T: type) Err!T {
+        fn func(impl: Impl, ally: ?std.mem.Allocator, comptime T: type) Err!T {
+            _ = impl;
+            _ = ally;
+
             unreachable;
         }
     };

--- a/src/de/interfaces/variant_access.zig
+++ b/src/de/interfaces/variant_access.zig
@@ -10,7 +10,7 @@ pub fn VariantAccess(
     comptime Err: type,
     /// A namespace containing methods that `Impl` must define or can override.
     comptime methods: struct {
-        payloadSeed: ?PayloadSeedFn(Impl, Err) = null,
+        payloadSeed: PayloadSeedFn(Impl, Err) = null,
         payload: ?PayloadFn(Impl, Err) = null,
         isPayloadAllocated: ?IsPayloadAllocatedFn(Impl) = null,
     },
@@ -66,7 +66,7 @@ fn PayloadSeedFn(comptime Impl: type, comptime Err: type) type {
         }
     };
 
-    return @TypeOf(Lambda.func);
+    return ?@TypeOf(Lambda.func);
 }
 
 fn PayloadFn(comptime Impl: type, comptime Err: type) type {

--- a/src/de/interfaces/variant_access.zig
+++ b/src/de/interfaces/variant_access.zig
@@ -24,7 +24,7 @@ pub fn VariantAccess(
 
             pub const Error = Err;
 
-            pub fn payloadSeed(self: Self, ally: ?std.mem.Allocator, seed: anytype) Error!@TypeOf(seed).Value {
+            pub fn payloadSeed(self: Self, ally: ?std.mem.Allocator, seed: anytype) Err!@TypeOf(seed).Value {
                 if (methods.payloadSeed) |func| {
                     return try func(self.impl, ally, seed);
                 }
@@ -32,7 +32,7 @@ pub fn VariantAccess(
                 @compileError("payloadSeed is not implemented by type: " ++ @typeName(Impl));
             }
 
-            pub fn payload(self: Self, ally: ?std.mem.Allocator, comptime Payload: type) Error!Payload {
+            pub fn payload(self: Self, ally: ?std.mem.Allocator, comptime Payload: type) Err!Payload {
                 if (methods.payload) |func| {
                     return try func(self.impl, ally, Payload);
                 }

--- a/src/de/interfaces/variant_access.zig
+++ b/src/de/interfaces/variant_access.zig
@@ -61,7 +61,10 @@ pub fn VariantAccess(
 
 fn PayloadSeedFn(comptime Impl: type, comptime Err: type) type {
     const Lambda = struct {
-        fn func(_: Impl, _: ?std.mem.Allocator, seed: anytype) Err!@TypeOf(seed).Value {
+        fn func(impl: Impl, ally: ?std.mem.Allocator, seed: anytype) Err!@TypeOf(seed).Value {
+            _ = impl;
+            _ = ally;
+
             unreachable;
         }
     };
@@ -71,7 +74,10 @@ fn PayloadSeedFn(comptime Impl: type, comptime Err: type) type {
 
 fn PayloadFn(comptime Impl: type, comptime Err: type) type {
     const Lambda = struct {
-        fn func(_: Impl, _: ?std.mem.Allocator, comptime Payload: type) Err!Payload {
+        fn func(impl: Impl, ally: ?std.mem.Allocator, comptime Payload: type) Err!Payload {
+            _ = impl;
+            _ = ally;
+
             unreachable;
         }
     };


### PR DESCRIPTION
## Better Documentation

Before this PR, `getty.de.MapAccess`'s documentation looked like this:

<img width="773" alt="image" src="https://github.com/getty-zig/getty/assets/25558240/633bad45-7393-44e7-ae99-fd6f5dcbad1e">

After this PR, its documentation looks like this:

<img width="790" alt="image" src="https://github.com/getty-zig/getty/assets/25558240/dc0e5bb2-40bc-4e2f-9ae5-35c8909a64d7">

And if you click on one of the method types, you are sent to the source code where you can clearly see the full signature of the method.

<img width="759" alt="image" src="https://github.com/getty-zig/getty/assets/25558240/378f2429-31f6-4658-86c4-592897ba2e40">

## Clearer Optionality

Also, notice the difference between `nextKeySeed`'s type and `nextKey`'s types in the second screenshot. The former is not prefixed with a `?`. While all interface methods are technically optional (for reasons irrelevant to this PR), some methods are "provided" by Getty for the user's convenience (i.e., they have a default implementation that is used if the user doesn't provide one).

Provided methods are now prefixed with a `?` to indicate their optionality, while "required" methods do not display the leading `?` in order to indicate to the user that they do not have default implementations.