### PR TITLE
Introduce lifetime parameter to visitString

### DIFF
--- a/src/de/blocks/slice.zig
+++ b/src/de/blocks/slice.zig
@@ -44,25 +44,31 @@ test "deserialize - slice, string" {
 
     const tests = .{
         .{
-            .name = "no sentinel",
+            .name = "no sentinel (copied)",
             .tokens = &.{.{ .String = "abc" }},
             .want = @as([]u8, &no_sentinel),
         },
         .{
-            .name = "no sentinel, const",
+            .name = "no sentinel, const (borrowed)",
             .tokens = &.{.{ .String = "abc" }},
             .want = @as([]const u8, &no_sentinel),
         },
         .{
-            .name = "sentinel",
-            .tokens = &.{.{ .String = "abc" }},
-            .want = @as([:0]u8, &sentinel),
+            .name = "sentinel (input has a sentinel)",
+            .tokens = &.{.{ .StringZ = "abc" }},
+            .want = @as([:0]const u8, &sentinel),
         },
         .{
-            .name = "sentinel, const",
+            .name = "sentinel, const (input has no sentinel)",
             .tokens = &.{.{ .String = "abc" }},
             .want = @as([:0]const u8, &sentinel),
         },
+        .{
+            .name = "sentinel (input has no sentinel, const -> mut)",
+            .tokens = &.{.{ .String = "abc" }},
+            .want = @as([:0]u8, &sentinel),
+        },
+        // TODO: Add test case for []u8 input to []const u8 output with and without sentinel.
     };
 
     inline for (tests) |t| {

--- a/src/de/de.zig
+++ b/src/de/de.zig
@@ -33,6 +33,13 @@ pub const de = struct {
     /// An implementation of `getty.de.Seed` that ignores values.
     pub const Ignored = @import("impls/seed/ignored.zig").Ignored;
 
+    /// The lifetime of the Getty String passed to a visitor's `visitString`
+    /// method.
+    pub const StringLifetime = @import("lifetime.zig").StringLifetime;
+
+    /// The lifetime of an access method's return value.
+    pub const ValueLifetime = @import("lifetime.zig").ValueLifetime;
+
     ////////////////////////////////////////////////////////////////////////////////
     // Namespaces
     ////////////////////////////////////////////////////////////////////////////////

--- a/src/de/impls/deserializer/content.zig
+++ b/src/de/impls/deserializer/content.zig
@@ -7,6 +7,7 @@ const getty_deserialize = @import("../../deserialize.zig").deserialize;
 const getty_error = @import("../../error.zig").Error;
 const MapAccessInterface = @import("../../interfaces/map_access.zig").MapAccess;
 const SeqAccessInterface = @import("../../interfaces/seq_access.zig").SeqAccess;
+const StringLifetime = @import("../../lifetime.zig").StringLifetime;
 const UnionAccessInterface = @import("../../interfaces/union_access.zig").UnionAccess;
 const VariantAccessInterface = @import("../../interfaces/variant_access.zig").VariantAccess;
 const VisitorInterface = @import("../../interfaces/visitor.zig").Visitor;
@@ -79,7 +80,7 @@ pub const ContentDeserializer = struct {
                 const int = v.to(@TypeOf(visitor).Value) catch unreachable;
                 break :blk try visitor.visitInt(ally, De, int);
             },
-            .String => |v| try visitor.visitString(ally, De, v),
+            .String => |v| try visitor.visitString(ally, De, v, .managed),
             else => error.InvalidType,
         };
     }
@@ -141,7 +142,7 @@ pub const ContentDeserializer = struct {
 
     fn deserializeString(self: Self, ally: std.mem.Allocator, visitor: anytype) getty_error!@TypeOf(visitor).Value {
         return switch (self.content) {
-            .String => |v| try visitor.visitString(ally, De, v),
+            .String => |v| try visitor.visitString(ally, De, v, .managed),
             else => error.InvalidType,
         };
     }

--- a/src/de/impls/visitor/content.zig
+++ b/src/de/impls/visitor/content.zig
@@ -97,7 +97,7 @@ fn visitString(
 ) Deserializer.Err!Content {
     switch (lt) {
         .heap => return .{ .String = @as([]const u8, input) },
-        .stack, .owned => {
+        .stack, .managed => {
             const copy = try ally.alloc(u8, input.len);
             std.mem.copy(u8, copy, input);
             return .{ .String = copy };

--- a/src/de/impls/visitor/content.zig
+++ b/src/de/impls/visitor/content.zig
@@ -3,6 +3,7 @@ const std = @import("std");
 const Content = @import("../../content.zig").Content;
 const ContentMultiArrayList = @import("../../content.zig").ContentMultiArrayList;
 const getty_deserialize = @import("../../deserialize.zig").deserialize;
+const StringLifetime = @import("../../lifetime.zig").StringLifetime;
 const VisitorInterface = @import("../../interfaces/visitor.zig").Visitor;
 
 const Visitor = @This();
@@ -87,11 +88,21 @@ fn visitSome(_: @This(), ally: std.mem.Allocator, deserializer: anytype) @TypeOf
     } };
 }
 
-fn visitString(_: @This(), ally: std.mem.Allocator, comptime Deserializer: type, input: anytype) Deserializer.Err!Content {
-    const output = try ally.alloc(u8, input.len);
-    std.mem.copy(u8, output, input);
-
-    return .{ .String = output };
+fn visitString(
+    _: @This(),
+    ally: std.mem.Allocator,
+    comptime Deserializer: type,
+    input: anytype,
+    lt: StringLifetime,
+) Deserializer.Err!Content {
+    switch (lt) {
+        .heap => return .{ .String = @as([]const u8, input) },
+        .stack, .owned => {
+            const copy = try ally.alloc(u8, input.len);
+            std.mem.copy(u8, copy, input);
+            return .{ .String = copy };
+        },
+    }
 }
 
 fn visitUnion(_: @This(), ally: std.mem.Allocator, comptime Deserializer: type, ua: anytype, va: anytype) Deserializer.Err!Content {

--- a/src/de/impls/visitor/enum.zig
+++ b/src/de/impls/visitor/enum.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 
 const getAttributes = @import("../../attributes.zig").getAttributes;
+const StringLifetime = @import("../../lifetime.zig").StringLifetime;
 const VisitorInterface = @import("../../interfaces/visitor.zig").Visitor;
 
 pub fn Visitor(comptime Enum: type) type {
@@ -18,7 +19,12 @@ pub fn Visitor(comptime Enum: type) type {
 
         const Value = Enum;
 
-        fn visitInt(_: Self, _: std.mem.Allocator, comptime Deserializer: type, input: anytype) Deserializer.Err!Value {
+        fn visitInt(
+            _: Self,
+            _: std.mem.Allocator,
+            comptime Deserializer: type,
+            input: anytype,
+        ) Deserializer.Err!Value {
             @setEvalBranchQuota(10_000);
 
             const fields = std.meta.fields(Value);
@@ -47,7 +53,13 @@ pub fn Visitor(comptime Enum: type) type {
             return e;
         }
 
-        fn visitString(_: Self, _: std.mem.Allocator, comptime Deserializer: type, input: anytype) Deserializer.Err!Value {
+        fn visitString(
+            _: Self,
+            _: std.mem.Allocator,
+            comptime Deserializer: type,
+            input: anytype,
+            _: StringLifetime,
+        ) Deserializer.Err!Value {
             @setEvalBranchQuota(10_000);
 
             const fields = std.meta.fields(Value);

--- a/src/de/impls/visitor/ignored.zig
+++ b/src/de/impls/visitor/ignored.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 
+const StringLifetime = @import("../../lifetime.zig").StringLifetime;
 const VisitorInterface = @import("../../interfaces/visitor.zig").Visitor;
 
 pub fn Visitor(comptime Ignored: type) type {
@@ -17,7 +18,7 @@ pub fn Visitor(comptime Ignored: type) type {
                 .visitNull = visitNothing,
                 .visitSeq = visitSeq,
                 .visitSome = visitSome,
-                .visitString = visitAny,
+                .visitString = visitString,
                 .visitUnion = visitUnion,
                 .visitVoid = visitNothing,
             },
@@ -50,6 +51,10 @@ pub fn Visitor(comptime Ignored: type) type {
         }
 
         fn visitSome(_: Self, _: std.mem.Allocator, deserializer: anytype) @TypeOf(deserializer).Err!Value {
+            return .{};
+        }
+
+        fn visitString(_: Self, _: std.mem.Allocator, comptime Deserializer: type, _: anytype, _: StringLifetime) Deserializer.Err!Value {
             return .{};
         }
 

--- a/src/de/impls/visitor/net_address.zig
+++ b/src/de/impls/visitor/net_address.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 
+const StringLifetime = @import("../../lifetime.zig").StringLifetime;
 const VisitorInterface = @import("../../interfaces/visitor.zig").Visitor;
 
 pub fn Visitor(comptime NetAddress: type) type {
@@ -16,7 +17,13 @@ pub fn Visitor(comptime NetAddress: type) type {
 
         const Value = NetAddress;
 
-        fn visitString(_: Self, _: std.mem.Allocator, comptime Deserializer: type, input: anytype) Deserializer.Err!Value {
+        fn visitString(
+            _: Self,
+            _: ?std.mem.Allocator,
+            comptime Deserializer: type,
+            input: anytype,
+            _: StringLifetime,
+        ) Deserializer.Err!Value {
             const max_ipv6_chars = 47;
             const max_port_chars = 6;
 

--- a/src/de/impls/visitor/pointer.zig
+++ b/src/de/impls/visitor/pointer.zig
@@ -3,6 +3,8 @@ const std = @import("std");
 const blocks = @import("../../blocks.zig");
 const find_db = @import("../../find.zig").find_db;
 const has_attributes = @import("../../../attributes.zig").has_attributes;
+const StringLifetime = @import("../../lifetime.zig").StringLifetime;
+
 const VisitorInterface = @import("../../interfaces/visitor.zig").Visitor;
 
 pub fn Visitor(comptime Pointer: type) type {
@@ -103,12 +105,18 @@ pub fn Visitor(comptime Pointer: type) type {
             return value;
         }
 
-        fn visitString(_: Self, ally: std.mem.Allocator, comptime Deserializer: type, input: anytype) Deserializer.Err!Value {
+        fn visitString(
+            _: Self,
+            ally: std.mem.Allocator,
+            comptime Deserializer: type,
+            input: anytype,
+            lt: StringLifetime,
+        ) Deserializer.Err!Value {
             const value = try ally.create(Child);
             errdefer ally.destroy(value);
 
             var cv = ChildVisitor(Deserializer){};
-            value.* = try cv.visitor().visitString(ally, Deserializer, input);
+            value.* = try cv.visitor().visitString(ally, Deserializer, input, lt);
 
             return value;
         }

--- a/src/de/impls/visitor/semantic_version.zig
+++ b/src/de/impls/visitor/semantic_version.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 
+const StringLifetime = @import("../../lifetime.zig").StringLifetime;
 const VisitorInterface = @import("../../interfaces/visitor.zig").Visitor;
 
 const Visitor = @This();
@@ -14,18 +15,25 @@ pub usingnamespace VisitorInterface(
 
 const Value = std.SemanticVersion;
 
-fn visitString(_: Visitor, ally: std.mem.Allocator, comptime Deserializer: type, input: anytype) Deserializer.Err!Value {
+fn visitString(
+    _: Visitor,
+    ally: std.mem.Allocator,
+    comptime Deserializer: type,
+    input: anytype,
+    lt: StringLifetime,
+) Deserializer.Err!Value {
     var ver = std.SemanticVersion.parse(input) catch return error.InvalidValue;
 
-    if (ver.pre == null and ver.build == null) {
-        return ver;
-    }
+    switch (lt) {
+        .heap => {},
+        .stack, .owned => {
+            if (ver.pre == null and ver.build == null) {
+                return ver;
+            }
 
-    if (ver.pre) |pre| {
-        ver.pre = try ally.dupe(u8, pre);
-    }
-    if (ver.build) |build| {
-        ver.build = try ally.dupe(u8, build);
+            if (ver.pre) |pre| ver.pre = try ally.dupe(u8, pre);
+            if (ver.build) |build| ver.build = try ally.dupe(u8, build);
+        },
     }
 
     return ver;

--- a/src/de/impls/visitor/semantic_version.zig
+++ b/src/de/impls/visitor/semantic_version.zig
@@ -26,7 +26,7 @@ fn visitString(
 
     switch (lt) {
         .heap => {},
-        .stack, .owned => {
+        .stack, .managed => {
             if (ver.pre == null and ver.build == null) {
                 return ver;
             }

--- a/src/de/impls/visitor/slice.zig
+++ b/src/de/impls/visitor/slice.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 
+const StringLifetime = @import("../../lifetime.zig").StringLifetime;
 const VisitorInterface = @import("../../interfaces/visitor.zig").Visitor;
 
 pub fn Visitor(comptime Slice: type) type {
@@ -33,17 +34,46 @@ pub fn Visitor(comptime Slice: type) type {
             return try list.toOwnedSlice();
         }
 
-        fn visitString(_: Self, ally: std.mem.Allocator, comptime Deserializer: type, input: anytype) Deserializer.Err!Value {
+        // input is only used directly if it the following are true:
+        //
+        //   1. input is a Heap value.
+        //   2. The sentinel values of input and Value match.
+        //   3. Either constness of input and Value match or are compatible
+        //      (i.e., Value is const and input is not const).
+        //
+        //  Otherwise, input is copied into a new slice.
+        fn visitString(
+            _: Self,
+            ally: std.mem.Allocator,
+            comptime Deserializer: type,
+            input: anytype,
+            lt: StringLifetime,
+        ) Deserializer.Err!Value {
             if (Child != u8) {
                 return error.InvalidType;
             }
 
-            const sentinel = @typeInfo(Value).Pointer.sentinel;
+            const v_info = @typeInfo(Value).Pointer;
 
-            const output = try ally.alloc(u8, input.len + @intFromBool(sentinel != null));
+            switch (lt) {
+                .heap => {
+                    const i_info = @typeInfo(@TypeOf(input)).Pointer;
+
+                    const sentinels_match = (v_info.sentinel == null) == (i_info.sentinel == null);
+                    const constness_match = v_info.is_const == i_info.is_const;
+                    const constness_compat = v_info.is_const and !i_info.is_const;
+
+                    if (sentinels_match and (constness_match or constness_compat)) {
+                        return @as(Value, input);
+                    }
+                },
+                .stack, .owned => {},
+            }
+
+            const output = try ally.alloc(u8, input.len + @intFromBool(v_info.sentinel != null));
             std.mem.copy(u8, output, input);
 
-            if (sentinel) |s| {
+            if (v_info.sentinel) |s| {
                 const sentinel_char = @as(*const u8, @ptrCast(s)).*;
                 output[input.len] = sentinel_char;
                 return output[0..input.len :sentinel_char];

--- a/src/de/impls/visitor/slice.zig
+++ b/src/de/impls/visitor/slice.zig
@@ -67,7 +67,7 @@ pub fn Visitor(comptime Slice: type) type {
                         return @as(Value, input);
                     }
                 },
-                .stack, .owned => {},
+                .stack, .managed => {},
             }
 
             const output = try ally.alloc(u8, input.len + @intFromBool(v_info.sentinel != null));

--- a/src/de/impls/visitor/uri.zig
+++ b/src/de/impls/visitor/uri.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 
+const StringLifetime = @import("../../lifetime.zig").StringLifetime;
 const VisitorInterface = @import("../../interfaces/visitor.zig").Visitor;
 
 const Visitor = @This();
@@ -14,26 +15,37 @@ pub usingnamespace VisitorInterface(
 
 const Value = std.Uri;
 
-fn visitString(_: Visitor, ally: std.mem.Allocator, comptime Deserializer: type, input: anytype) Deserializer.Err!Value {
+fn visitString(
+    _: Visitor,
+    ally: std.mem.Allocator,
+    comptime Deserializer: type,
+    input: anytype,
+    lt: StringLifetime,
+) Deserializer.Err!Value {
     var uri = std.Uri.parse(input) catch return error.InvalidValue;
 
-    uri.scheme = try ally.dupe(u8, uri.scheme);
-    uri.path = try ally.dupe(u8, uri.path);
+    switch (lt) {
+        .heap => {},
+        .stack, .owned => {
+            uri.scheme = try ally.dupe(u8, uri.scheme);
+            uri.path = try ally.dupe(u8, uri.path);
 
-    if (uri.host) |host| {
-        uri.host = try ally.dupe(u8, host);
-    }
-    if (uri.user) |user| {
-        uri.user = try ally.dupe(u8, user);
-    }
-    if (uri.password) |password| {
-        uri.password = try ally.dupe(u8, password);
-    }
-    if (uri.query) |query| {
-        uri.query = try ally.dupe(u8, query);
-    }
-    if (uri.fragment) |fragment| {
-        uri.fragment = try ally.dupe(u8, fragment);
+            if (uri.host) |host| {
+                uri.host = try ally.dupe(u8, host);
+            }
+            if (uri.user) |user| {
+                uri.user = try ally.dupe(u8, user);
+            }
+            if (uri.password) |password| {
+                uri.password = try ally.dupe(u8, password);
+            }
+            if (uri.query) |query| {
+                uri.query = try ally.dupe(u8, query);
+            }
+            if (uri.fragment) |fragment| {
+                uri.fragment = try ally.dupe(u8, fragment);
+            }
+        },
     }
 
     return uri;

--- a/src/de/impls/visitor/uri.zig
+++ b/src/de/impls/visitor/uri.zig
@@ -26,7 +26,7 @@ fn visitString(
 
     switch (lt) {
         .heap => {},
-        .stack, .owned => {
+        .stack, .managed => {
             uri.scheme = try ally.dupe(u8, uri.scheme);
             uri.path = try ally.dupe(u8, uri.path);
 

--- a/src/de/lifetime.zig
+++ b/src/de/lifetime.zig
@@ -1,0 +1,13 @@
+/// The lifetime of the Getty String passed to a visitor's `visitString`
+/// method.
+pub const StringLifetime = enum {
+    stack,
+    heap,
+    managed,
+};
+
+/// The lifetime of an access method's return value.
+pub const ValueLifetime = enum {
+    heap,
+    managed,
+};

--- a/src/de/testing.zig
+++ b/src/de/testing.zig
@@ -115,7 +115,7 @@ pub fn deserializeErrWithLifetime(
 pub fn Deserializer(comptime user_dbt: anytype, comptime deserializer_dbt: anytype) type {
     return struct {
         tokens: []const Token,
-        str_lifetime: StringLifetime,
+        str_lifetime: StringLifetime = .stack,
 
         const Self = @This();
 

--- a/src/de/testing.zig
+++ b/src/de/testing.zig
@@ -8,6 +8,7 @@ const err = @import("error.zig");
 const MapAccessInterface = @import("interfaces/map_access.zig").MapAccess;
 const Result = @import("deserialize.zig").Result;
 const SeqAccessInterface = @import("interfaces/seq_access.zig").SeqAccess;
+const StringLifetime = @import("lifetime.zig").StringLifetime;
 const testing = @import("../testing.zig");
 const Token = testing.Token;
 const UnionAccessInterface = @import("interfaces/union_access.zig").UnionAccess;
@@ -66,9 +67,55 @@ pub fn deserializeErr(
     return result;
 }
 
+pub fn deserializeWithLifetime(
+    ally: ?std.mem.Allocator,
+    comptime test_case: ?[]const u8,
+    comptime block: type,
+    comptime Want: type,
+    input: []const Token,
+    lifetime: StringLifetime,
+) !Want {
+    return deserializeErrWithLifetime(ally, block, Want, input, lifetime) catch |e| {
+        if (test_case) |t| {
+            return testing.logErr(t, e);
+        }
+
+        return e;
+    };
+}
+
+pub fn deserializeErrWithLifetime(
+    ally: ?std.mem.Allocator,
+    comptime block: type,
+    comptime Want: type,
+    input: []const Token,
+    lifetime: StringLifetime,
+) !Want {
+    comptime {
+        std.debug.assert(@typeInfo(block) == .Struct);
+        std.debug.assert(std.meta.trait.hasFunctions(block, .{ "deserialize", "Visitor" }));
+    }
+
+    var d = DefaultDeserializer{
+        .tokens = input,
+        .str_lifetime = lifetime,
+    };
+    const deserializer = d.deserializer();
+
+    var v = block.Visitor(Want){};
+    const visitor = v.visitor();
+
+    const got = try block.deserialize(ally, Want, deserializer, visitor);
+
+    try std.testing.expect(d.remaining() == 0);
+
+    return got;
+}
+
 pub fn Deserializer(comptime user_dbt: anytype, comptime deserializer_dbt: anytype) type {
     return struct {
         tokens: []const Token,
+        str_lifetime: StringLifetime,
 
         const Self = @This();
 
@@ -163,7 +210,7 @@ pub fn Deserializer(comptime user_dbt: anytype, comptime deserializer_dbt: anyty
                     .U32 => |v| try visitor.visitInt(ally, De, v),
                     .U64 => |v| try visitor.visitInt(ally, De, v),
                     .U128 => |v| try visitor.visitInt(ally, De, v),
-                    .String => |v| try visitor.visitString(ally, De, v),
+                    inline .String, .StringZ => |v| try visitor.visitString(ally, De, v, .stack),
                     else => |v| std.debug.panic("deserialization did not expect this token: {s}", .{@tagName(v)}),
                 },
                 .Map => |v| blk: {
@@ -177,7 +224,7 @@ pub fn Deserializer(comptime user_dbt: anytype, comptime deserializer_dbt: anyty
                 },
                 .Null => try visitor.visitNull(ally, De),
                 .Some => try visitor.visitSome(ally, self.deserializer()),
-                .String => |v| try visitor.visitString(ally, De, v),
+                inline .String, .StringZ => |v| try visitor.visitString(ally, De, v, self.str_lifetime),
                 .Void => try visitor.visitVoid(ally, De),
                 .Seq => |v| blk: {
                     var s = Seq{ .de = self, .len = v.len, .end = .SeqEnd };

--- a/src/ser/testing.zig
+++ b/src/ser/testing.zig
@@ -262,6 +262,7 @@ pub fn Serializer(comptime user_sbt: anytype, comptime serializer_sbt: anytype) 
                         .SeqEnd => try expectEqual(@field(token, "SeqEnd"), @field(expected, "SeqEnd")),
                         .Some => try expectEqual(@field(token, "Some"), @field(expected, "Some")),
                         .String => try expectEqualSlices(u8, @field(token, "String"), @field(expected, "String")),
+                        .StringZ => try expectEqualSlices(u8, @field(token, "StringZ"), @field(expected, "StringZ")),
                         .Struct => {
                             const tok = @field(token, "Struct");
                             const e = @field(expected, "Struct");

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -24,6 +24,7 @@ pub const Token = union(enum) {
     F128: f128,
 
     String: []const u8,
+    StringZ: [:0]const u8,
 
     Null,
     Some,


### PR DESCRIPTION
Next up is updating visitString's return type and then updating the return type of the access methods.

I want to get this merged in first though to see if there are any performance improvements with slices now being used directly if they're Heap values.