### PR TITLE
Update visitString return type to include used Boolean

### DIFF
--- a/src/de/de.zig
+++ b/src/de/de.zig
@@ -7,6 +7,9 @@ pub const de = struct {
     /// A managed, deserialized value.
     pub const Result = @import("deserialize.zig").Result;
 
+    /// The return value of a `getty.de.Visitor`'s `visitString` method.
+    pub const VisitStringReturn = @import("interfaces/visitor.zig").VisitStringReturn;
+
     /// Deserialization and access interface for Getty Maps.
     pub const MapAccess = @import("interfaces/map_access.zig").MapAccess;
 

--- a/src/de/impls/deserializer/content.zig
+++ b/src/de/impls/deserializer/content.zig
@@ -80,7 +80,10 @@ pub const ContentDeserializer = struct {
                 const int = v.to(@TypeOf(visitor).Value) catch unreachable;
                 break :blk try visitor.visitInt(ally, De, int);
             },
-            .String => |v| try visitor.visitString(ally, De, v, .managed),
+            .String => |v| blk: {
+                var ret = try visitor.visitString(ally, De, v, .managed);
+                break :blk ret.value;
+            },
             else => error.InvalidType,
         };
     }
@@ -142,7 +145,10 @@ pub const ContentDeserializer = struct {
 
     fn deserializeString(self: Self, ally: std.mem.Allocator, visitor: anytype) getty_error!@TypeOf(visitor).Value {
         return switch (self.content) {
-            .String => |v| try visitor.visitString(ally, De, v, .managed),
+            .String => |v| blk: {
+                var ret = try visitor.visitString(ally, De, v, .managed);
+                break :blk ret.value;
+            },
             else => error.InvalidType,
         };
     }

--- a/src/de/impls/visitor/array.zig
+++ b/src/de/impls/visitor/array.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 
 const StringLifetime = @import("../../lifetime.zig").StringLifetime;
 const VisitorInterface = @import("../../interfaces/visitor.zig").Visitor;
+const VisitStringReturn = @import("../../interfaces/visitor.zig").VisitStringReturn;
 
 pub fn Visitor(comptime Array: type) type {
     return struct {
@@ -54,7 +55,7 @@ pub fn Visitor(comptime Array: type) type {
             comptime Deserializer: type,
             input: anytype,
             _: StringLifetime,
-        ) Deserializer.Err!Value {
+        ) Deserializer.Err!VisitStringReturn(Value) {
             if (Child != u8) {
                 return error.InvalidType;
             }
@@ -66,7 +67,7 @@ pub fn Visitor(comptime Array: type) type {
             }
 
             @memcpy(&arr, input);
-            return arr;
+            return .{ .value = arr, .used = false };
         }
 
         const Child = std.meta.Child(Value);

--- a/src/de/impls/visitor/enum.zig
+++ b/src/de/impls/visitor/enum.zig
@@ -3,6 +3,7 @@ const std = @import("std");
 const getAttributes = @import("../../attributes.zig").getAttributes;
 const StringLifetime = @import("../../lifetime.zig").StringLifetime;
 const VisitorInterface = @import("../../interfaces/visitor.zig").Visitor;
+const VisitStringReturn = @import("../../interfaces/visitor.zig").VisitStringReturn;
 
 pub fn Visitor(comptime Enum: type) type {
     return struct {
@@ -59,7 +60,7 @@ pub fn Visitor(comptime Enum: type) type {
             comptime Deserializer: type,
             input: anytype,
             _: StringLifetime,
-        ) Deserializer.Err!Value {
+        ) Deserializer.Err!VisitStringReturn(Value) {
             @setEvalBranchQuota(10_000);
 
             const fields = std.meta.fields(Value);
@@ -108,7 +109,8 @@ pub fn Visitor(comptime Enum: type) type {
                 };
 
                 if (name_cmp or aliases_cmp) {
-                    return std.meta.stringToEnum(Value, field.name) orelse error.UnknownVariant;
+                    var e = std.meta.stringToEnum(Value, field.name) orelse return error.UnknownVariant;
+                    return .{ .value = e, .used = false };
                 }
             }
 

--- a/src/de/impls/visitor/ignored.zig
+++ b/src/de/impls/visitor/ignored.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 
 const StringLifetime = @import("../../lifetime.zig").StringLifetime;
 const VisitorInterface = @import("../../interfaces/visitor.zig").Visitor;
+const VisitStringReturn = @import("../../interfaces/visitor.zig").VisitStringReturn;
 
 pub fn Visitor(comptime Ignored: type) type {
     return struct {
@@ -54,8 +55,8 @@ pub fn Visitor(comptime Ignored: type) type {
             return .{};
         }
 
-        fn visitString(_: Self, _: std.mem.Allocator, comptime Deserializer: type, _: anytype, _: StringLifetime) Deserializer.Err!Value {
-            return .{};
+        fn visitString(_: Self, _: std.mem.Allocator, comptime Deserializer: type, _: anytype, _: StringLifetime) Deserializer.Err!VisitStringReturn(Value) {
+            return .{ .value = .{}, .used = false };
         }
 
         fn visitUnion(_: Self, _: std.mem.Allocator, comptime Deserializer: type, _: anytype, _: anytype) Deserializer.Err!Value {

--- a/src/de/impls/visitor/net_address.zig
+++ b/src/de/impls/visitor/net_address.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 
 const StringLifetime = @import("../../lifetime.zig").StringLifetime;
 const VisitorInterface = @import("../../interfaces/visitor.zig").Visitor;
+const VisitStringReturn = @import("../../interfaces/visitor.zig").VisitStringReturn;
 
 pub fn Visitor(comptime NetAddress: type) type {
     return struct {
@@ -100,7 +101,9 @@ pub fn Visitor(comptime NetAddress: type) type {
             }
 
             const end = addr_port_len - port_len - 1; // The 1 is for the colon separator.
-            return std.net.Address.resolveIp(addr_port_str[0..end], port) catch error.InvalidValue;
+            var addr = std.net.Address.resolveIp(addr_port_str[0..end], port) catch return error.InvalidValue;
+
+            return .{ .value = addr, .used = false };
         }
 
         const Child = std.meta.Child(Value);

--- a/src/de/impls/visitor/semantic_version.zig
+++ b/src/de/impls/visitor/semantic_version.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 
 const StringLifetime = @import("../../lifetime.zig").StringLifetime;
 const VisitorInterface = @import("../../interfaces/visitor.zig").Visitor;
+const VisitStringReturn = @import("../../interfaces/visitor.zig").VisitStringReturn;
 
 const Visitor = @This();
 
@@ -21,20 +22,17 @@ fn visitString(
     comptime Deserializer: type,
     input: anytype,
     lt: StringLifetime,
-) Deserializer.Err!Value {
+) Deserializer.Err!VisitStringReturn(Value) {
     var ver = std.SemanticVersion.parse(input) catch return error.InvalidValue;
 
+    var used = false;
     switch (lt) {
-        .heap => {},
+        .heap => used = true,
         .stack, .managed => {
-            if (ver.pre == null and ver.build == null) {
-                return ver;
-            }
-
             if (ver.pre) |pre| ver.pre = try ally.dupe(u8, pre);
             if (ver.build) |build| ver.build = try ally.dupe(u8, build);
         },
     }
 
-    return ver;
+    return .{ .value = ver, .used = used };
 }

--- a/src/de/impls/visitor/uri.zig
+++ b/src/de/impls/visitor/uri.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 
 const StringLifetime = @import("../../lifetime.zig").StringLifetime;
 const VisitorInterface = @import("../../interfaces/visitor.zig").Visitor;
+const VisitStringReturn = @import("../../interfaces/visitor.zig").VisitStringReturn;
 
 const Visitor = @This();
 
@@ -21,11 +22,12 @@ fn visitString(
     comptime Deserializer: type,
     input: anytype,
     lt: StringLifetime,
-) Deserializer.Err!Value {
+) Deserializer.Err!VisitStringReturn(Value) {
     var uri = std.Uri.parse(input) catch return error.InvalidValue;
 
+    var used = false;
     switch (lt) {
-        .heap => {},
+        .heap => used = true,
         .stack, .managed => {
             uri.scheme = try ally.dupe(u8, uri.scheme);
             uri.path = try ally.dupe(u8, uri.path);
@@ -48,5 +50,5 @@ fn visitString(
         },
     }
 
-    return uri;
+    return .{ .value = uri, .used = used };
 }

--- a/src/de/interfaces/visitor.zig
+++ b/src/de/interfaces/visitor.zig
@@ -116,7 +116,7 @@ pub fn Visitor(
                 comptime Deserializer: type,
                 input: anytype,
                 lifetime: StringLifetime,
-            ) Deserializer.Err!T {
+            ) Deserializer.Err!VisitStringReturn(T) {
                 if (methods.visitString) |func| {
                     comptime {
                         if (!std.meta.trait.isZigString(@TypeOf(input))) {
@@ -151,6 +151,14 @@ pub fn Visitor(
         pub fn visitor(impl: Impl) @"getty.de.Visitor" {
             return .{ .impl = impl };
         }
+    };
+}
+
+/// The return value of a `getty.de.Visitor`'s `visitString` method.
+pub fn VisitStringReturn(comptime T: type) type {
+    return struct {
+        value: T,
+        used: bool,
     };
 }
 
@@ -215,10 +223,7 @@ fn VisitStringFn(comptime Impl: type, comptime T: type) type {
             comptime Deserializer: type,
             input: anytype,
             lifeitime: StringLifetime,
-        ) Deserializer.Err!struct {
-            value: T,
-            used: bool,
-        } {
+        ) Deserializer.Err!VisitStringReturn(T) {
             _ = lifeitime;
             _ = impl;
             _ = ally;

--- a/src/de/interfaces/visitor.zig
+++ b/src/de/interfaces/visitor.zig
@@ -215,7 +215,10 @@ fn VisitStringFn(comptime Impl: type, comptime T: type) type {
             comptime Deserializer: type,
             input: anytype,
             lifeitime: StringLifetime,
-        ) Deserializer.Err!T {
+        ) Deserializer.Err!struct {
+            value: T,
+            used: bool,
+        } {
             _ = lifeitime;
             _ = impl;
             _ = ally;

--- a/src/de/testing.zig
+++ b/src/de/testing.zig
@@ -210,7 +210,10 @@ pub fn Deserializer(comptime user_dbt: anytype, comptime deserializer_dbt: anyty
                     .U32 => |v| try visitor.visitInt(ally, De, v),
                     .U64 => |v| try visitor.visitInt(ally, De, v),
                     .U128 => |v| try visitor.visitInt(ally, De, v),
-                    inline .String, .StringZ => |v| try visitor.visitString(ally, De, v, .stack),
+                    inline .String, .StringZ => |v| blk: {
+                        var ret = try visitor.visitString(ally, De, v, .stack);
+                        break :blk ret.value;
+                    },
                     else => |v| std.debug.panic("deserialization did not expect this token: {s}", .{@tagName(v)}),
                 },
                 .Map => |v| blk: {
@@ -224,7 +227,10 @@ pub fn Deserializer(comptime user_dbt: anytype, comptime deserializer_dbt: anyty
                 },
                 .Null => try visitor.visitNull(ally, De),
                 .Some => try visitor.visitSome(ally, self.deserializer()),
-                inline .String, .StringZ => |v| try visitor.visitString(ally, De, v, self.str_lifetime),
+                inline .String, .StringZ => |v| blk: {
+                    var ret = try visitor.visitString(ally, De, v, self.str_lifetime);
+                    break :blk ret.value;
+                },
                 .Void => try visitor.visitVoid(ally, De),
                 .Seq => |v| blk: {
                     var s = Seq{ .de = self, .len = v.len, .end = .SeqEnd };


### PR DESCRIPTION
This'll allow deserializers to know whether or not the value passed to `visitString` was used. If so, then it should not be freed unless the managing entity wants to free it.