### PR TITLE
fix compiler errors on 0.12.0-dev.1828+225fe6ddb

### DIFF
--- a/src/attributes.zig
+++ b/src/attributes.zig
@@ -135,7 +135,7 @@ pub fn is_attributes(
         const A = Attributes(T, attributes);
         var a = A{};
 
-        inline for (std.meta.fields(@TypeOf(attributes))) |field| {
+        for (std.meta.fields(@TypeOf(attributes))) |field| {
             @field(a, field.name) = @field(attributes, field.name);
         }
 

--- a/src/ser/serialize.zig
+++ b/src/ser/serialize.zig
@@ -39,7 +39,7 @@ pub fn serialize(
         }
 
         // Process default SBs.
-        inline for (st) |sb| {
+        for (st) |sb| {
             if (sb.is(T)) {
                 break :blk sb;
             }


### PR DESCRIPTION
error: redundant inline keyword in comptime scope