### PR TITLE
build: update to new Build API

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 const package_name = "getty";
 const package_path = "src/getty.zig";
 
-pub fn build(b: *std.build.Builder) void {
+pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
@@ -13,8 +13,8 @@ pub fn build(b: *std.build.Builder) void {
 
     // Export Getty as a module.
     _ = b.addModule(package_name, .{
-        .source_file = .{ .path = package_path },
-        .dependencies = &.{
+        .root_source_file = .{ .path = package_path },
+        .imports = &.{
             .{ .name = "protest", .module = protest_module },
         },
     });
@@ -28,24 +28,22 @@ pub fn build(b: *std.build.Builder) void {
         // Serialization tests.
         const t_ser = b.addTest(.{
             .name = "serialization test",
-            .root_source_file = .{ .path = "src/ser/ser.zig" },
+            .root_source_file = .{ .path = "src/ser_test.zig" },
             .target = target,
             .optimize = optimize,
-            .main_pkg_path = .{ .path = "src/" },
         });
-        t_ser.addModule("protest", protest_module);
+        t_ser.root_module.addImport("protest", protest_module);
         test_ser_step.dependOn(&b.addRunArtifact(t_ser).step);
         test_all_step.dependOn(test_ser_step);
 
         // Deserialization tests.
         const t_de = b.addTest(.{
             .name = "deserialization test",
-            .root_source_file = .{ .path = "src/de/de.zig" },
+            .root_source_file = .{ .path = "src/de_test.zig" },
             .target = target,
             .optimize = optimize,
-            .main_pkg_path = .{ .path = "src/" },
         });
-        t_de.addModule("protest", protest_module);
+        t_de.root_module.addImport("protest", protest_module);
         test_de_step.dependOn(&b.addRunArtifact(t_de).step);
         test_all_step.dependOn(test_de_step);
     }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -10,8 +10,8 @@
     },
     .dependencies = .{
         .protest = .{
-            .url = "https://github.com/ibokuri/protest/archive/65b2b3113115dfd61c5bdf70629d6332d62680c2.tar.gz",
-            .hash = "1220f2081dabcbbae17e04c9c5b731e54d7e64c9c50f5e3434ec3e42d6bb7b1f7c31",
+            .url = "git+https://github.com/ibokuri/protest.git#fc657aeda91f8c022e47b26f3edbe5ad49d2479b",
+            .hash = "122054a16e7c3c1eb526828257b8a8e2d048e4f179aca5f5672d8ee2b6b9cea8481d",
         },
     },
 }

--- a/src/de_test.zig
+++ b/src/de_test.zig
@@ -1,0 +1,3 @@
+test {
+    _ = @import("de/de.zig");
+}

--- a/src/ser_test.zig
+++ b/src/ser_test.zig
@@ -1,0 +1,3 @@
+test {
+    _ = @import("ser/ser.zig");
+}


### PR DESCRIPTION
This updates the project to be compatible with the new build system changes.

The additional `ser_test.zig` and `de_test.zig` files are required as changing a module's root path is no longer supported.
