### PR TITLE
deps: Update ibokuri dependency url

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -10,7 +10,7 @@
     },
     .dependencies = .{
         .protest = .{
-            .url = "git+https://github.com/ibokuri/protest.git#bae398b701e763ef18480aa3cfcca103716996de",
+            .url = "https://github.com/ibokuri/protest/archive/bae398b701e763ef18480aa3cfcca103716996de.tar.gz",
             .hash = "1220c70517d1bc1b3734c9c4fe81045b1927320b2590d8af28be32883f5fd4d3af8d",
         },
     },


### PR DESCRIPTION
Rewrites the `protest` dependency url in `build.zig.zon` (doesn't change the dependency version). Fixes the following error seen on latest Zig master (`0.12.0-dev.2811+3cafb9655`):

```sh
getty/build.zig.zon:13:20: error: unable to unpack git files: BadZlibHeader
            .url = "git+https://github.com/ibokuri/protest.git#bae398b701e763ef18480aa3cfcca103716996de",
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

---

To reproduce the error:

1. Add the latest Zig to your PATH
2. Clear Zig caches (to ensure Zig build will attempt to fetch the `protest` dependency instead of using a cached version; there might be a better way to do this that doesn't involve nuking the entire cache): `rm -rf ~/.cache/zig; cd path/to/getty; rm -rf zig-cache zig-out`
3. Run `zig build`
4. See the above error