### PR TITLE
Update to Zig 0.13.0-dev.249+ed75f6256

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -13,10 +13,10 @@ pub fn build(b: *std.Build) void {
     const protest_module = b.dependency("protest", target_optimize).module("protest");
 
     // Internal modules.
-    const attr_module = b.createModule(.{ .root_source_file = .{ .path = internal_dir ++ "attr/attr.zig" } });
-    const block_module = b.createModule(.{ .root_source_file = .{ .path = internal_dir ++ "block/block.zig" } });
-    const helpers_module = b.createModule(.{ .root_source_file = .{ .path = internal_dir ++ "helpers/helpers.zig" } });
-    const testing_module = b.createModule(.{ .root_source_file = .{ .path = internal_dir ++ "testing/testing.zig" } });
+    const attr_module = b.createModule(.{ .root_source_file = b.path(internal_dir ++ "attr/attr.zig") });
+    const block_module = b.createModule(.{ .root_source_file = b.path(internal_dir ++ "block/block.zig") });
+    const helpers_module = b.createModule(.{ .root_source_file = b.path(internal_dir ++ "helpers/helpers.zig") });
+    const testing_module = b.createModule(.{ .root_source_file = b.path(internal_dir ++ "testing/testing.zig") });
 
     // Package module.
     const imports = .{
@@ -31,7 +31,7 @@ pub fn build(b: *std.Build) void {
     };
 
     _ = b.addModule(package_name, .{
-        .root_source_file = .{ .path = package_path },
+        .root_source_file = b.path(package_path),
         .imports = &imports,
     });
 
@@ -52,7 +52,7 @@ pub fn build(b: *std.Build) void {
             for (args) |arg| {
                 const t_filter = b.addTest(.{
                     .name = "filtered test",
-                    .root_source_file = .{ .path = "src/getty.zig" },
+                    .root_source_file = b.path("src/getty.zig"),
                     .filter = arg,
                     .target = target,
                     .optimize = optimize,
@@ -70,7 +70,7 @@ pub fn build(b: *std.Build) void {
         // Serialization tests.
         const t_ser = b.addTest(.{
             .name = "serialization test",
-            .root_source_file = .{ .path = "src/ser/ser.zig" },
+            .root_source_file = b.path("src/ser/ser.zig"),
             .target = target,
             .optimize = optimize,
         });
@@ -81,7 +81,7 @@ pub fn build(b: *std.Build) void {
         // Deserialization tests.
         const t_de = b.addTest(.{
             .name = "deserialization test",
-            .root_source_file = .{ .path = "src/de/de.zig" },
+            .root_source_file = b.path("src/de/de.zig"),
             .target = target,
             .optimize = optimize,
         });
@@ -96,7 +96,7 @@ pub fn build(b: *std.Build) void {
 
         const doc_obj = b.addObject(.{
             .name = "docs",
-            .root_source_file = .{ .path = package_path },
+            .root_source_file = b.path(package_path),
             .target = target,
             .optimize = optimize,
         });

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -10,8 +10,8 @@
     },
     .dependencies = .{
         .protest = .{
-            .url = "https://github.com/ibokuri/protest/archive/339da6d86a9f1d00178e2b697d04ac8d2ba3f453.tar.gz",
-            .hash = "122023b5e4aa0d3dde9cbdcd09f3ac529ac37a10c2b26be82f1caf6d3792328fc9bd",
+            .url = "https://github.com/ibokuri/protest/archive/e7a9bc39c213985814a904b38e4506a6fbd537b2.tar.gz",
+            .hash = "122014736a658ee30f82e5c6e3038c95727690fe01fced2791b213dba10c65fba7c5",
         },
     },
 }


### PR DESCRIPTION
Updates build.zig due to changes in LazyPath.

Note: Before merging this PR, we need to update build.zig.zon after (https://github.com/ibokuri/protest/pull/1) is merged.